### PR TITLE
close socket connection issue

### DIFF
--- a/src/net/tootallnate/websocket/WebSocketClient.java
+++ b/src/net/tootallnate/websocket/WebSocketClient.java
@@ -120,9 +120,22 @@ public abstract class WebSocketClient implements Runnable, WebSocketListener {
   {    
 	  if (running)
 	  {
-		  running = false;  // must be called to stop do loop
-		  selector.wakeup();
-		  conn.close();		// synchronously calling onClose(conn)
+		  // must be called to stop do loop
+		  running = false;  
+		  
+		  // call this inside IF because it can be null if the connection has't started
+		  // but user is calling close()
+		  if (selector != null && conn != null)
+		  {
+			  selector.wakeup();
+			  conn.close();
+			  // close() is synchronously calling onClose(conn) so we don't have to
+		  }
+		  else
+		  {
+			  // connection has't started but the onClose events should be triggered
+			  onClose(conn);
+		  }
 	  }
   }
 
@@ -165,8 +178,13 @@ public abstract class WebSocketClient implements Runnable, WebSocketListener {
       selector = Selector.open();
 
       this.conn = new WebSocket(client, new LinkedBlockingQueue<ByteBuffer>(), this);
-      // At first, we're only interested in the 'CONNECT' keys.
-      client.register(selector, SelectionKey.OP_CONNECT);
+      // the client/selector can be null when closing the connection before its start
+      // so we have to call this part inside IF
+      if (client != null)
+      {
+          // At first, we're only interested in the 'CONNECT' keys.
+          client.register(selector, SelectionKey.OP_CONNECT);
+      }
 
     } catch (IOException ex) {
     	onIOError(conn, ex);


### PR DESCRIPTION
Close socket connection issue fix (connection do not close when manually calling close()).

Hey, I found a bug and I prepared a small fix. As explained, when you call close() it does not immediately close the connection and leave it opened for awhile. The problem was that to loop stopped after the connection was blocked. 

Please check and merge.
