### PR TITLE
Crtical fix inside run() loop

### DIFF
--- a/src/net/tootallnate/websocket/WebSocketClient.java
+++ b/src/net/tootallnate/websocket/WebSocketClient.java
@@ -218,7 +218,10 @@ public abstract class WebSocketClient implements Runnable, WebSocketListener {
         }
       } catch (IOException ex) {
     	  onIOError(conn, ex);
-      } catch (NoSuchAlgorithmException ex) {
+      } catch (Exception ex) {
+    	// NullPointerException is the most common error that can happen here
+    	// (e.g.when connection closes immediately)
+    	// TODO: user should handle that kind of events my himself
         ex.printStackTrace();
       }
     }


### PR DESCRIPTION
Hey, me again :). 

I'm testing again and again. I found another issue. There are cases when user "hacks" the program by opening and closing the connection (imagine the android activity going next-back-next-back...). In this case a NullPointerException can occur. It's not actually an error... well... we know that this can happen and we should just ignore it... it's true we could test each line inside run() but to just catch the exception is nicer.

As you can see I try to leave things simple with small commits.

Please merge.
