### PR TITLE
Don't set draft to null in releaseAndInitialize

### DIFF
--- a/src/net/tootallnate/websocket/WebSocketClient.java
+++ b/src/net/tootallnate/websocket/WebSocketClient.java
@@ -164,7 +164,6 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 	  client = null;
 	  selector = null;
 	  running = false;
-	  draft = null;
 	  number1 = 0;
 	  number2 = 0;
 	  key3 = null;


### PR DESCRIPTION
Draft's don't have a setter in WebSocketClient, so setting them to null in this method makes this method pretty much pointless.

I'm not sure if it's necessary to call this before connect after an error (say, in case the server restarts) but it seems like if the function is there and public it should not leave the client in a state where it's unusable.
