### PR TITLE
Doing a buf.rewind in channelWrite causes a problem with partially writt...

### DIFF
--- a/src/net/tootallnate/websocket/Draft.java
+++ b/src/net/tootallnate/websocket/Draft.java
@@ -134,6 +134,7 @@ public abstract class Draft{
 		bytebuffer.put ( httpheader );
 		if( content!=null )
 			bytebuffer.put ( content );
+		bytebuffer.flip();
 		return Collections.singletonList( bytebuffer );
 	}
 	

--- a/src/net/tootallnate/websocket/WebSocket.java
+++ b/src/net/tootallnate/websocket/WebSocket.java
@@ -395,7 +395,8 @@ public final class WebSocket {
   private void channelWrite(ByteBuffer buf) throws IOException{
 	  if(DEBUG) System.out.println("write: {"+new String(buf.array())+"}");
 	  //printBytes ( buf , buf.capacity () );
-	  buf.rewind ();
+	  // shouldn't rewind here because that will rewind partially written buffers
+	  //buf.rewind ();
 	  socketChannel.write(buf);
   }
   

--- a/src/net/tootallnate/websocket/drafts/Draft_10.java
+++ b/src/net/tootallnate/websocket/drafts/Draft_10.java
@@ -115,6 +115,7 @@ public class Draft_10 extends Draft {
 			buf.put ( mes );
 		//translateFrame ( buf.array () , buf.array ().length );
 		assert( buf.remaining() == 0 ):buf.remaining();
+		buf.flip();
 		return buf;
 	}
 

--- a/src/net/tootallnate/websocket/drafts/Draft_75.java
+++ b/src/net/tootallnate/websocket/drafts/Draft_75.java
@@ -65,7 +65,7 @@ public class Draft_75 extends Draft {
 	    b.put(START_OF_FRAME);
 	    b.put(pay);
 	    b.put(END_OF_FRAME);
-	    b.rewind();
+	    b.flip();
 	    return b;
 	}
 


### PR DESCRIPTION
...en buffers, which are placed on the buffer queue and then rewinded before sending the rest of the buffer.

Instead, buffers should be ready for writing to the socket before they are sent in to channelWrite.
I changed some rewinds to flips assuming that only what was written to the buffer should be written out to the socket.  flip sets the buffer limit to the position to which the buffer had been written.
