### PR TITLE
The LinkedBlockingQueue should not have a length. (currently 10)

### DIFF
--- a/src/net/tootallnate/websocket/WebSocket.java
+++ b/src/net/tootallnate/websocket/WebSocket.java
@@ -112,7 +112,7 @@ public final class WebSocket {
 
 	private void init( WebSocketListener listener, Draft draft, SocketChannel sockchannel ) {
 		this.sockchannel = sockchannel;
-		this.bufferQueue = new LinkedBlockingQueue<ByteBuffer>( 10 );
+		this.bufferQueue = new LinkedBlockingQueue<ByteBuffer>( );
 		this.handshakeComplete = false;
 		this.socketBuffer = ByteBuffer.allocate( 65558 );
 		socketBuffer.flip();


### PR DESCRIPTION
The LinkedBlockingQueue should not have a length.
If a message received has more then 10 messages being send back it
renders the socket useless.  Since the bufferQueue.put() method keeps
waiting forever for the queue to shrink.
