### PR TITLE
Fixed broken pipe error, which caused server to hang.

### DIFF
--- a/src/net/tootallnate/websocket/WebSocket.java
+++ b/src/net/tootallnate/websocket/WebSocket.java
@@ -412,7 +412,12 @@ public final class WebSocket {
 	public void flush() throws IOException {
 		ByteBuffer buffer = this.bufferQueue.peek();
 		while ( buffer != null ) {
-			sockchannel.write( buffer );
+			try {
+				sockchannel.write( buffer );
+			} catch (IOException e) {
+				closeConnection( 5, "", true );
+				break;
+			}
 			if( buffer.remaining() > 0 ) {
 				continue;
 			} else {


### PR DESCRIPTION
Broken Pipe Error which was caused by a bug when someone would disconnect before the file tried to send data to the client before the onclientclose was called, which would cause the server to completely lock up.
