### PR TITLE
Hang on WebSocketClient.close()

### DIFF
--- a/src/org/java_websocket/WebSocketImpl.java
+++ b/src/org/java_websocket/WebSocketImpl.java
@@ -404,12 +404,12 @@ public class WebSocketImpl extends WebSocket {
 		if( key != null ) {
 			// key.attach( null ); //see issue #114
 			key.cancel();
-			try {
-				channel.close();
-			} catch ( IOException e ) {
-				wsl.onWebsocketError( this, e );
-			}
-		}
+        }
+        try {
+            channel.close();
+        } catch ( IOException e ) {
+            wsl.onWebsocketError( this, e );
+        }
 		// sockchannel.close();
 		this.wsl.onWebsocketClose( this, code, message, remote );
 		if( draft != null )


### PR DESCRIPTION
I tried to use Java-WebSocket in my Android application, but its background thread hangs with high CPU usage when I call WebSocketClient.close().
After some investigation i found that it hangs because close() sends thread interrupt, but that doesn't lead to closing of channel so IO loop continues to run forever.
I don't know if this is a proper fix, but worked for me.
