### PR TITLE
Removing toLowerCase

### DIFF
--- a/src/main/java/org/java_websocket/handshake/HandshakedataImpl1.java
+++ b/src/main/java/org/java_websocket/handshake/HandshakedataImpl1.java
@@ -32,7 +32,7 @@ public class HandshakedataImpl1 implements HandshakeBuilder {
 
 	@Override
 	public String getFieldValue( String name ) {
-		String s = map.get( name.toLowerCase( Locale.ENGLISH ) );
+		String s = map.get( name );
 		if( s == null ) {
 			return "";
 		}
@@ -51,11 +51,11 @@ public class HandshakedataImpl1 implements HandshakeBuilder {
 
 	@Override
 	public void put( String name, String value ) {
-		map.put( name.toLowerCase( Locale.ENGLISH ), value );
+		map.put( name, value );
 	}
 
 	@Override
 	public boolean hasFieldValue( String name ) {
-		return map.containsKey( name.toLowerCase( Locale.ENGLISH ) );
+		return map.containsKey( name );
 	}
 }


### PR DESCRIPTION
Is there a reason all of the header fields are being lower cased? This actually caused requests I was making to a server I don't have control over to fail.
