### PR TITLE
Adding additional condition (checks 'CLOSED' status) for isNeedRead() method

### DIFF
--- a/src/main/java/org/java_websocket/SSLSocketChannel2.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel2.java
@@ -313,7 +313,8 @@ public class SSLSocketChannel2 implements ByteChannel, WrappedByteChannel {
 
 	@Override
 	public boolean isNeedRead() {
-		return inData.hasRemaining() || ( inCrypt.hasRemaining() && engineResult.getStatus() != Status.BUFFER_UNDERFLOW );
+		return inData.hasRemaining() || ( inCrypt.hasRemaining() && engineResult.getStatus() != Status.BUFFER_UNDERFLOW && 
+				engineResult.getStatus() != Status.CLOSED );
 	}
 
 	@Override


### PR DESCRIPTION
If connection closed isNeedRead() always returns true. We need to check the status of SSLResult for it.
