### PR TITLE
Solves issues with the CONNECT response being misinterpreted and others

### DIFF
--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -261,23 +261,28 @@ public class WebSocketImpl implements WebSocket {
 						return false;
 					}
 					ServerHandshake handshake = (ServerHandshake) tmphandshake;
-					handshakestate = draft.acceptHandshakeAsClient( handshakerequest, handshake );
-					if( handshakestate == HandshakeState.MATCHED ) {
-						try {
-							wsl.onWebsocketHandshakeReceivedAsClient( this, handshakerequest, handshake );
-						} catch ( InvalidDataException e ) {
-							flushAndClose( e.getCloseCode(), e.getMessage(), false );
-							return false;
-						} catch ( RuntimeException e ) {
-							wsl.onWebsocketError( this, e );
-							flushAndClose( CloseFrame.NEVER_CONNECTED, e.getMessage(), false );
-							return false;
+					if (!handshake.getHttpStatusMessage().equalsIgnoreCase("Connection Established"))	// Ignore Proxy CONNECT response
+					{
+						handshakestate = draft.acceptHandshakeAsClient( handshakerequest, handshake );
+						if( handshakestate == HandshakeState.MATCHED ) {
+							try {
+								wsl.onWebsocketHandshakeReceivedAsClient( this, handshakerequest, handshake );
+							} catch ( InvalidDataException e ) {
+								flushAndClose( e.getCloseCode(), e.getMessage(), false );
+								return false;
+							} catch ( RuntimeException e ) {
+								wsl.onWebsocketError( this, e );
+								flushAndClose( CloseFrame.NEVER_CONNECTED, e.getMessage(), false );
+								return false;
+							}
+							open( handshake );
+							return true;
+						} else {
+							close( CloseFrame.PROTOCOL_ERROR, "draft " + draft + " refuses handshake" );
 						}
-						open( handshake );
-						return true;
-					} else {
-						close( CloseFrame.PROTOCOL_ERROR, "draft " + draft + " refuses handshake" );
 					}
+					else
+						return false;
 				}
 			} catch ( InvalidHandshakeException e ) {
 				close( e );

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -419,10 +419,12 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 			b.append( host );
 			b.append( ":" );
 			b.append( getPort() );
-			b.append( " HTTP/1.1\n" );
+			b.append( " HTTP/1.1\r\n" );
 			b.append( "Host: " );
 			b.append( host );
-			b.append( "\n" );
+			b.append( ":" );
+			b.append( getPort() );
+			b.append( "\r\n\r\n" );
 			return b.toString();
 		}
 	}

--- a/src/main/java/org/java_websocket/handshake/HandshakedataImpl1.java
+++ b/src/main/java/org/java_websocket/handshake/HandshakedataImpl1.java
@@ -2,14 +2,14 @@ package org.java_websocket.handshake;
 
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.TreeMap;
+import java.util.LinkedHashMap;
 
 public class HandshakedataImpl1 implements HandshakeBuilder {
 	private byte[] content;
-	private TreeMap<String,String> map;
+	private LinkedHashMap<String,String> map;
 
 	public HandshakedataImpl1() {
-		map = new TreeMap<String,String>( String.CASE_INSENSITIVE_ORDER );
+		map = new LinkedHashMap<String,String>();
 	}
 
 	/*public HandshakedataImpl1( Handshakedata h ) {


### PR DESCRIPTION
Related to https://github.com/TooTallNate/Java-WebSocket/issues/88

Solves issues that were preventing it from working in Fiddler (and probably any other proxy)
- Now ignores the "Connection Established" response (which is the response to CONNECTION request) which precedes the "Switching Protocol" header when doing a proxy
- Fixed the CONNECT request headers for proxy
- Use LinkedHashMap instead of TreeMap to guarantee order of headers
