### PR TITLE
do not close executor service when first WebSocket is closed

### DIFF
--- a/src/main/java/org/java_websocket/SSLSocketChannel2.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel2.java
@@ -302,7 +302,6 @@ public class SSLSocketChannel2 implements ByteChannel, WrappedByteChannel {
 		if( socketChannel.isOpen() )
 			socketChannel.write( wrap( emptybuffer ) );// FIXME what if not all bytes can be written
 		socketChannel.close();
-		exec.shutdownNow();
 	}
 
 	private boolean isHandShakeComplete() {

--- a/src/main/java/org/java_websocket/server/DefaultSSLWebSocketServerFactory.java
+++ b/src/main/java/org/java_websocket/server/DefaultSSLWebSocketServerFactory.java
@@ -48,4 +48,11 @@ public class DefaultSSLWebSocketServerFactory implements WebSocketServer.WebSock
 	public WebSocketImpl createWebSocket( WebSocketAdapter a, List<Draft> d, Socket s ) {
 		return new WebSocketImpl( a, d );
 	}
+	
+	/**
+	* shutdown executor service
+	*/
+	public void shutdown() {
+		exec.shutdownNow();
+	}
 }


### PR DESCRIPTION
this caused the WebSocket service to die when SSL was used and an
ExecutorService was created inside DefaultSSLWebSocketServerFactory
