### PR TITLE
Fixed Issue #217 - memory leak caused by Thread(this).

### DIFF
--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -3,6 +3,7 @@ package org.java_websocket.client;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.ref.WeakReference;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.Socket;
@@ -46,7 +47,8 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 
 	private Proxy proxy = Proxy.NO_PROXY;
 
-	private Thread writeThread;
+	private WeakReference<Thread> readThread;
+	private WeakReference<Thread> writeThread;
 
 	private Draft draft;
 
@@ -57,7 +59,7 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 	private CountDownLatch closeLatch = new CountDownLatch( 1 );
 
 	private int connectTimeout = 0;
-
+	
 	/** This open a websocket connection as specified by rfc6455 */
 	public WebSocketClient( URI serverURI ) {
 		this( serverURI, new Draft_17() );
@@ -104,10 +106,12 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 	 * Initiates the websocket connection. This method does not block.
 	 */
 	public void connect() {
-		if( writeThread != null )
+		if( readThread != null )
 			throw new IllegalStateException( "WebSocketClient objects are not reuseable" );
-		writeThread = new Thread( this );
-		writeThread.start();
+		
+		Thread reader = new Thread(this, "WSC Read");
+		reader.start();
+		readThread = new WeakReference<Thread>(reader) ;
 	}
 
 	/**
@@ -174,8 +178,9 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 			return;
 		}
 
-		writeThread = new Thread( new WebsocketWriteThread() );
-		writeThread.start();
+		Thread write = new Thread( new WebsocketWriteThread() );
+		write.start();
+		writeThread = new WeakReference<Thread>(write);
 
 		byte[] rawbuffer = new byte[ WebSocketImpl.RCVBUF ];
 		int readBytes;
@@ -274,8 +279,13 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 	public final void onWebsocketClose( WebSocket conn, int code, String reason, boolean remote ) {
 		connectLatch.countDown();
 		closeLatch.countDown();
-		if( writeThread != null )
-			writeThread.interrupt();
+		if( writeThread != null && writeThread.get() != null) {
+			writeThread.get().interrupt();
+		}
+		if( readThread != null && readThread.get() != null) {
+			readThread.get().interrupt();
+		}
+		
 		try {
 			if( socket != null )
 				socket.close();
@@ -345,7 +355,7 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 	private class WebsocketWriteThread implements Runnable {
 		@Override
 		public void run() {
-			Thread.currentThread().setName( "WebsocketWriteThread" );
+			Thread.currentThread().setName( "WSC Write" );
 			try {
 				while ( !Thread.interrupted() ) {
 					ByteBuffer buffer = engine.outQueue.take();


### PR DESCRIPTION
- `writeThread = new Thread( this );` caused a circular reference so WebSocketClient and writeThread was never garbage collected.
- use 2 thread instance variables instead of starting `writeThread` with a `read`, then reassigning it as a writer in it's run method. Now there is a `readThread` and `writeThread`, as WeakReference<Thread>
#### Before Fix - 242 Objects Retained

![screen shot 2013-11-21 at 9 48 31 am](https://f.cloud.github.com/assets/1975119/1592957/6e0511de-52c4-11e3-9abc-0d392edd6587.png)
#### After Fix - 1 Object Retained

![screen shot 2013-11-21 at 9 50 46 am](https://f.cloud.github.com/assets/1975119/1592971/b16ffd44-52c4-11e3-979a-87fc904cf547.png)
