### PR TITLE
Add SSL support to WebSocketClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@ repositories {
 }
 
 group = 'org.java_websocket'
-version = '1.2.1-SNAPSHOT'
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+version = '1.3.1-SNAPSHOT'
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 configurations {
     deployerJars

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -6,6 +6,8 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.Socket;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.NotYetConnectedException;
@@ -164,6 +166,9 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 			}
 			if( !socket.isBound() )
 				socket.connect( new InetSocketAddress( uri.getHost(), getPort() ), connectTimeout );
+                        SSLSocketFactory f = (SSLSocketFactory) SSLSocketFactory.getDefault();
+                        socket = f.createSocket(socket, uri.getHost(), getPort(), true);
+
 			istream = socket.getInputStream();
 			ostream = socket.getOutputStream();
 


### PR DESCRIPTION
Uses java 7 SSLSocketFactory when the scheme is wss.

Note this introduces a dependency on java 7.
