### PR TITLE
Add callback to obtain handshake response as client in case of handshake failure.

### DIFF
--- a/src/main/java/org/java_websocket/SocketChannelIOHelper.java
+++ b/src/main/java/org/java_websocket/SocketChannelIOHelper.java
@@ -61,7 +61,7 @@ public class SocketChannelIOHelper {
 			} while ( buffer != null );
 		}
 
-		if( ws.outQueue.isEmpty() && ws.isFlushAndClose() && ws.getDraft().getRole() == Role.SERVER ) {//
+		if( ws.outQueue.isEmpty() && ws.isFlushAndClose() && ws.getRole() == Role.SERVER ) {//
 			synchronized ( ws ) {
 				ws.closeConnection();
 			}

--- a/src/main/java/org/java_websocket/WebSocketAdapter.java
+++ b/src/main/java/org/java_websocket/WebSocketAdapter.java
@@ -34,6 +34,16 @@ public abstract class WebSocketAdapter implements WebSocketListener {
 
 	/**
 	 * This default implementation does not do anything which will cause the connections to always progress.
+	 *
+	 * @see org.java_websocket.WebSocketListener#onWebsocketHandshakeReceivedAsClientFailed(WebSocket, ClientHandshake, ServerHandshake)
+	 */
+	@Override
+	public void onWebsocketHandshakeReceivedAsClientFailed( WebSocket conn, ClientHandshake request, ServerHandshake response ) {
+
+	}
+
+	/**
+	 * This default implementation does not do anything which will cause the connections to always progress.
 	 * 
 	 * @see org.java_websocket.WebSocketListener#onWebsocketHandshakeSentAsClient(WebSocket, ClientHandshake)
 	 */

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -253,6 +253,7 @@ public class WebSocketImpl implements WebSocket {
 								ClientHandshake handshake = (ClientHandshake) tmphandshake;
 								handshakestate = d.acceptHandshakeAsServer( handshake );
 								if( handshakestate == HandshakeState.MATCHED ) {
+									draft = d;
 									resourceDescriptor = handshake.getResourceDescriptor();
 									ServerHandshakeBuilder response;
 									try {
@@ -266,7 +267,6 @@ public class WebSocketImpl implements WebSocket {
 										return false;
 									}
 									write( d.createHandshake( d.postProcessHandshakeResponseAsServer( handshake, response ), role ) );
-									draft = d;
 									open( handshake );
 									return true;
 								}

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -88,7 +88,7 @@ public class WebSocketImpl implements WebSocket {
 
 	private Draft draft = null;
 
-	private Role role;
+	private final Role role;
 
 	private Opcode current_continuous_frame_opcode = null;
 
@@ -104,13 +104,42 @@ public class WebSocketImpl implements WebSocket {
 	
 	private String resourceDescriptor = null;
 
+	private static BlockingQueue<ByteBuffer> createQueue(){
+		return new LinkedBlockingQueue<ByteBuffer>();
+	}
+
 	/**
 	 * crates a websocket with server role
+	 * @param listener Listener
+	 * @param drafts Known drafts (may be null to use default drafts)
 	 */
-	public WebSocketImpl( WebSocketListener listener , List<Draft> drafts ) {
-		this( listener, (Draft) null );
-		this.role = Role.SERVER;
-		// draft.copyInstance will be called when the draft is first needed
+	public static WebSocketImpl createServer( WebSocketListener listener , List<Draft> drafts ) {
+		return new WebSocketImpl( listener, drafts );
+	}
+
+	/**
+	 * crates a websocket with client role
+	 *
+	 * @param @param listener Listener
+	 * @param draft Draft to use
+	 */
+	public static WebSocketImpl createClient( WebSocketListener listener , Draft draft ) {
+		return new WebSocketImpl( listener, draft );
+	}
+
+	/**
+	 * Constructor for  a websocket with server role
+	 * @param listener Listener
+	 * @param drafts Known drafts (may be null to use default drafts)
+	 */
+	private WebSocketImpl( WebSocketListener listener , List<Draft> drafts ) {
+		if(null == listener){
+			throw new IllegalArgumentException( "listener must not be null" );
+		}
+		role = Role.SERVER;
+		wsl = listener;
+		outQueue = createQueue();
+		inQueue = createQueue();
 		if( drafts == null || drafts.isEmpty() ) {
 			knownDrafts = defaultdraftlist;
 		} else {
@@ -119,20 +148,23 @@ public class WebSocketImpl implements WebSocket {
 	}
 
 	/**
-	 * crates a websocket with client role
+	 * Constructor for a websocket with client role
 	 * 
-	 * @param socket
-	 *            may be unbound
+	 * @param @param listener Listener
+	 * @param draft Draft to use
 	 */
-	public WebSocketImpl( WebSocketListener listener , Draft draft ) {
-		if( listener == null || ( draft == null && role == Role.SERVER ) )// socket can be null because we want do be able to create the object without already having a bound channel
-			throw new IllegalArgumentException( "parameters must not be null" );
-		this.outQueue = new LinkedBlockingQueue<ByteBuffer>();
-		inQueue = new LinkedBlockingQueue<ByteBuffer>();
-		this.wsl = listener;
-		this.role = Role.CLIENT;
-		if( draft != null )
-			this.draft = draft.copyInstance();
+	private WebSocketImpl( WebSocketListener listener , Draft draft ) {
+		if(null == listener){
+			throw new IllegalArgumentException( "listener must not be null" );
+		}
+		if(null == draft){
+			throw new IllegalArgumentException( "draft must not be null" );
+		}
+		role = Role.CLIENT;
+		wsl = listener;
+		outQueue = createQueue();
+		inQueue = createQueue();
+		this.draft = draft.copyInstance();
 	}
 
 	@Deprecated

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -761,6 +761,10 @@ public class WebSocketImpl implements WebSocket {
 		return wsl.getLocalSocketAddress( this );
 	}
 
+	Role getRole() {
+		return role;
+	}
+
 	@Override
 	public Draft getDraft() {
 		return draft;

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -287,6 +287,16 @@ public class WebSocketImpl implements WebSocket {
 						open( handshake );
 						return true;
 					} else {
+						if (handshake.getHttpStatus() != 101) {
+							// if HTTP-status is not 101, let client get a chance to obtain the HTTP response
+							// and take action upon that as per regular HTTP procedures.
+							// (http://tools.ietf.org/html/rfc6455#section-4.1)
+							try {
+								wsl.onWebsocketHandshakeReceivedAsClientFailed(this, handshakerequest, handshake);
+							} catch (RuntimeException e) {
+								// do nothing, fall through and close socket
+							}
+						}
 						close( CloseFrame.PROTOCOL_ERROR, "draft " + draft + " refuses handshake" );
 					}
 				}

--- a/src/main/java/org/java_websocket/WebSocketListener.java
+++ b/src/main/java/org/java_websocket/WebSocketListener.java
@@ -51,6 +51,18 @@ public interface WebSocketListener {
 	public void onWebsocketHandshakeReceivedAsClient( WebSocket conn, ClientHandshake request, ServerHandshake response ) throws InvalidDataException;
 
 	/**
+	 * Called on the client side when the socket connection is about to be established, but failed due to the handshake
+	 * could not be verified. E.g. the server rejected the request with a regular HTTP response, and the client
+	 * can then use this callback as a way of obtain that HTTP response, e.g. status code.
+	 *
+	 * @param conn     The WebSocket related to this event
+	 * @param request  The handshake initially send out to the server by this websocket.
+	 * @param response The handshake the server sent in response to the request.
+	 */
+	public void onWebsocketHandshakeReceivedAsClientFailed(WebSocket conn, ClientHandshake request, ServerHandshake response);
+
+
+	/**
 	 * Called on the client side when the socket connection is first established, and the WebSocketImpl
 	 * handshake has just been sent.
 	 * 

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -82,7 +82,7 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 		this.draft = protocolDraft;
 		this.headers = httpHeaders;
 		this.connectTimeout = connectTimeout;
-		this.engine = new WebSocketImpl( this, protocolDraft );
+		this.engine = WebSocketImpl.createClient( this , protocolDraft );
 	}
 
 	/**

--- a/src/main/java/org/java_websocket/server/DefaultSSLWebSocketServerFactory.java
+++ b/src/main/java/org/java_websocket/server/DefaultSSLWebSocketServerFactory.java
@@ -4,6 +4,7 @@ import java.net.Socket;
 import java.nio.channels.ByteChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -41,11 +42,13 @@ public class DefaultSSLWebSocketServerFactory implements WebSocketServer.WebSock
 
 	@Override
 	public WebSocketImpl createWebSocket( WebSocketAdapter a, Draft d, Socket c ) {
-		return new WebSocketImpl( a, d );
+		List<Draft> drafts = new ArrayList<Draft>(1);
+		drafts.add(d);
+		return WebSocketImpl.createServer( a, drafts );
 	}
 
 	@Override
 	public WebSocketImpl createWebSocket( WebSocketAdapter a, List<Draft> d, Socket s ) {
-		return new WebSocketImpl( a, d );
+		return WebSocketImpl.createServer( a, d );
 	}
 }

--- a/src/main/java/org/java_websocket/server/DefaultWebSocketServerFactory.java
+++ b/src/main/java/org/java_websocket/server/DefaultWebSocketServerFactory.java
@@ -3,6 +3,7 @@ package org.java_websocket.server;
 import java.net.Socket;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.java_websocket.WebSocketAdapter;
@@ -13,11 +14,13 @@ import org.java_websocket.server.WebSocketServer.WebSocketServerFactory;
 public class DefaultWebSocketServerFactory implements WebSocketServerFactory {
 	@Override
 	public WebSocketImpl createWebSocket( WebSocketAdapter a, Draft d, Socket s ) {
-		return new WebSocketImpl( a, d );
+		List<Draft> drafts = new ArrayList<Draft>(1);
+		drafts.add(d);
+		return WebSocketImpl.createServer( a, drafts );
 	}
 	@Override
 	public WebSocketImpl createWebSocket( WebSocketAdapter a, List<Draft> d, Socket s ) {
-		return new WebSocketImpl( a, d );
+		return WebSocketImpl.createServer( a, d );
 	}
 	@Override
 	public SocketChannel wrapChannel( SocketChannel channel, SelectionKey key ) {

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -514,7 +514,11 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 	public final void onWebsocketClose( WebSocket conn, int code, String reason, boolean remote ) {
 		selector.wakeup();
 		try {
-			if( removeConnection( conn ) ) {
+			if(conn.getReadyState() == WebSocket.READYSTATE.NOT_YET_CONNECTED){
+				// if the WebSocket was never opened (i.e. rejected before opened), then the connection will not have
+				// been added, so removeConnection should not be called.
+				onClose( conn, code, reason, remote );
+			} else if( removeConnection( conn ) ) {
 				onClose( conn, code, reason, remote );
 			}
 		} finally {


### PR DESCRIPTION
This provides a listener callback to obtain the server's handshake response in case it was rejected with a HTTP status code != 101.

E.g. if the server rejects the WebSocket upgrade request by issuing a
HTTP response with 503 status code, then this HTTP response data can be
obtained via
WebSocketListener.onWebsocketHandshakeReceivedAsClientFailed(WebSocket,
ClientHandshake, ServerHandshake).

If there already is any other way of obtaining the server's response including http status code, please enlighten me :) Thanks / Christoffer
