### PR TITLE
close selector to relese socket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,19 +46,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <developers>

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -283,6 +283,7 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 			server.configureBlocking( false );
 			ServerSocket socket = server.socket();
 			socket.setReceiveBufferSize( WebSocketImpl.RCVBUF );
+			socket.setReuseAddress(true);
 			socket.bind( address );
 			selector = Selector.open();
 			server.register( selector, server.validOps() );
@@ -394,6 +395,13 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 			if( decoders != null ) {
 				for( WebSocketWorker w : decoders ) {
 					w.interrupt();
+				}
+			}
+			if (selector != null) {
+				try {
+					selector.close();
+				} catch (IOException e) {
+					onError( null, e);
 				}
 			}
 			if( server != null ) {


### PR DESCRIPTION
(without it it now working property at least in java7u67 (but works on
older some older version and eg open jdk) and causing bind error on reuse
