### PR TITLE
Fixed NullPointerException on random data

### DIFF
--- a/src/main/java/org/java_websocket/SocketChannelIOHelper.java
+++ b/src/main/java/org/java_websocket/SocketChannelIOHelper.java
@@ -61,7 +61,8 @@ public class SocketChannelIOHelper {
 			} while ( buffer != null );
 		}
 
-		if( ws.outQueue.isEmpty() && ws.isFlushAndClose() && ws.getDraft().getRole() == Role.SERVER ) {//
+		if( ws.outQueue.isEmpty() && ws.isFlushAndClose() && 
+				( ws.getDraft() == null || ws.getDraft().getRole() == Role.SERVER ) ) {//
 			synchronized ( ws ) {
 				ws.closeConnection();
 			}


### PR DESCRIPTION
I have experienced a NullPointerException when I simly opened a session with telnet and sent some random data.
The draft parameter of the websocket implementation is still null when the getRole method is called.
Added a condition, the method is not called if the draft is null.
