### PR TITLE
Possibility to override worker thread allocation logic in WebSocketServer #279

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build
 *.svn
 *~
 target
+.idea
 *.ipr
 *.iml
 *.iws

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -565,7 +565,7 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 	 *            may be null if the error does not belong to a single connection
 	 */
 	@Override
-	public final void onWebsocketError( WebSocket conn, Exception ex ) {
+	public void onWebsocketError( WebSocket conn, Exception ex ) {
 		onError( conn, ex );
 	}
 

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -79,7 +79,7 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 
 	private volatile AtomicBoolean isclosed = new AtomicBoolean( false );
 
-	private List<WebSocketWorker> decoders;
+	protected List<WebSocketWorker> decoders;
 
 	private List<WebSocketImpl> iqueue;
 	private BlockingQueue<ByteBuffer> buffers;
@@ -184,7 +184,7 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 	public void start() {
 		if( selectorthread != null )
 			throw new IllegalStateException( getClass().getName() + " can only be started once." );
-		new Thread( this ).start();;
+		new Thread( this ).start();
 	}
 
 	/**
@@ -219,9 +219,6 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 
 		synchronized ( this ) {
 			if( selectorthread != null ) {
-				if( Thread.currentThread() != selectorthread ) {
-
-				}
 				if( selectorthread != Thread.currentThread() ) {
 					if( socketsToClose.size() > 0 )
 						selectorthread.join( timeout );// isclosed will tell the selectorthread to go down after the last connection was closed
@@ -422,7 +419,7 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 		return ByteBuffer.allocate( WebSocketImpl.RCVBUF );
 	}
 
-	private void queue( WebSocketImpl ws ) throws InterruptedException {
+	protected void queue( WebSocketImpl ws ) throws InterruptedException {
 		if( ws.workerThread == null ) {
 			ws.workerThread = decoders.get( queueinvokes % decoders.size() );
 			queueinvokes++;


### PR DESCRIPTION
https://github.com/TooTallNate/Java-WebSocket/issues/279

Sorry for doubling the issue, I always forgot that PR automatically creates an issue. 

The second modification explanation: 
`WebSocketServer#onError`  method is called on all kinds of errors : server/client ones with Runtime and IO Exceptions from both, there is no way to tell whether it's just a client or server fail... Having a way of overriding `WebSocketServer#onWebsocketError` allows you to listen to client connection fails only. 
