### PR TITLE
Proper release for non-blocking sockets

### DIFF
--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -399,6 +399,7 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 			if( server != null ) {
 				try {
 					server.close();
+					selector.select();
 				} catch ( IOException e ) {
 					onError( null, e );
 				}


### PR DESCRIPTION
Apparently you have to call `selector.select()` after you have closed a non-blocking socket for the OS-resources to be released. The documentation is very lacking in this regard, see this [bug report](https://bugs.openjdk.java.net/browse/JDK-5073504?page=com.atlassian.jira.plugin.system.issuetabpanels:changehistory-tabpanel) for more info.

For generally cases this will not pose a problem, I stumbled upon this when I tried to use this lib in an OSGi environment.
