### PR TITLE
Preventing the server to crash because of a NPE. Issue #224

### DIFF
--- a/src/main/java/org/java_websocket/SocketChannelIOHelper.java
+++ b/src/main/java/org/java_websocket/SocketChannelIOHelper.java
@@ -61,7 +61,7 @@ public class SocketChannelIOHelper {
 			} while ( buffer != null );
 		}
 
-		if( ws.outQueue.isEmpty() && ws.isFlushAndClose() && ws.getDraft().getRole() == Role.SERVER ) {//
+		if( ws != null && ws.outQueue.isEmpty() && ws.isFlushAndClose() && ws.getDraft() != null && ws.getDraft().getRole() != null && ws.getDraft().getRole() == Role.SERVER ) {//
 			synchronized ( ws ) {
 				ws.closeConnection();
 			}

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -707,7 +707,11 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 					assert ( buf != null );
 					try {
 						ws.decode( buf );
-					} finally {
+					} catch(Exception e){
+						System.err.println("Error while reading from remote connection: " + e);
+					}
+					
+					finally {
 						pushBuffer( buf );
 					}
 				}


### PR DESCRIPTION
NullPointerException is making the server to crash.  This is also a security breach because an intruder could make your server to crash by simply connecting and start typing random characters. This commit would fix this.