### PR TITLE
Don't shutdown the ssl executor service too early

### DIFF
--- a/src/main/java/org/java_websocket/SSLSocketChannel2.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel2.java
@@ -308,7 +308,6 @@ public class SSLSocketChannel2 implements ByteChannel, WrappedByteChannel {
 		if( socketChannel.isOpen() )
 			socketChannel.write( wrap( emptybuffer ) );// FIXME what if not all bytes can be written
 		socketChannel.close();
-		exec.shutdownNow();
 	}
 
 	private boolean isHandShakeComplete() {

--- a/src/main/java/org/java_websocket/server/DefaultSSLWebSocketServerFactory.java
+++ b/src/main/java/org/java_websocket/server/DefaultSSLWebSocketServerFactory.java
@@ -48,4 +48,8 @@ public class DefaultSSLWebSocketServerFactory implements WebSocketServer.WebSock
 	public WebSocketImpl createWebSocket( WebSocketAdapter a, List<Draft> d, Socket s ) {
 		return new WebSocketImpl( a, d );
 	}
+	@Override
+	public void close() {
+		exec.shutdown();
+	}
 }

--- a/src/main/java/org/java_websocket/server/DefaultWebSocketServerFactory.java
+++ b/src/main/java/org/java_websocket/server/DefaultWebSocketServerFactory.java
@@ -23,4 +23,7 @@ public class DefaultWebSocketServerFactory implements WebSocketServerFactory {
 	public SocketChannel wrapChannel( SocketChannel channel, SelectionKey key ) {
 		return (SocketChannel) channel;
 	}
+	@Override
+	public void close() {
+	}
 }

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -215,6 +215,8 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 			ws.close( CloseFrame.GOING_AWAY );
 		}
 
+		wsf.close();
+
 		synchronized ( this ) {
 			if( selectorthread != null && selectorthread != Thread.currentThread() ) {
 				selector.wakeup();
@@ -729,5 +731,7 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 		 * @return The channel on which the read and write operations will be performed.<br>
 		 */
 		public ByteChannel wrapChannel( SocketChannel channel, SelectionKey key ) throws IOException;
+
+		public void close();
 	}
 }


### PR DESCRIPTION
The ExecutorService held by the DefaultSSLWebSocketServerFactory was being shutdown
when the first SSLSocketChannel2 got closed, making it unusable for further connections.
It's now being closed on server stop instead.
