### PR TITLE
Replaced String.isEmpty() with String.length() for Android API level 8 compatibility

### DIFF
--- a/src/main/java/org/java_websocket/drafts/Draft_76.java
+++ b/src/main/java/org/java_websocket/drafts/Draft_76.java
@@ -130,7 +130,7 @@ public class Draft_76 extends Draft_75 {
 
 	@Override
 	public HandshakeState acceptHandshakeAsServer( ClientHandshake handshakedata ) {
-		if( handshakedata.getFieldValue( "Upgrade" ).equals( "WebSocket" ) && handshakedata.getFieldValue( "Connection" ).contains( "Upgrade" ) && handshakedata.getFieldValue( "Sec-WebSocket-Key1" ).length() > 0 && !handshakedata.getFieldValue( "Sec-WebSocket-Key2" ).isEmpty() && handshakedata.hasFieldValue( "Origin" ) )
+		if( handshakedata.getFieldValue( "Upgrade" ).equals( "WebSocket" ) && handshakedata.getFieldValue( "Connection" ).contains( "Upgrade" ) && handshakedata.getFieldValue( "Sec-WebSocket-Key1" ).length() > 0 && handshakedata.getFieldValue( "Sec-WebSocket-Key2" ).length() > 0 && handshakedata.hasFieldValue( "Origin" ) )
 			return HandshakeState.MATCHED;
 		return HandshakeState.NOT_MATCHED;
 	}


### PR DESCRIPTION
Since minimum required JDK for this library is Android 1.6 (API 4), as stated in README.markdown, calls to String.isEmpty() are replaced with String.length() .
