### PR TITLE
make continuation response from server, following client->server PING… [fixes issue #392]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.java-websocket</groupId>
     <artifactId>Java-WebSocket</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.0.continuations</version>
     <packaging>jar</packaging>
     <name>Java WebSocket</name>
     <url>http://java-websocket.org/</url>

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -350,6 +350,9 @@ public class WebSocketImpl implements WebSocket {
 				} else if( curop == Opcode.PONG ) {
 					wsl.onWebsocketPong( this, f );
 					continue;
+				} else if( curop == Opcode.CONTINUATION ) {
+					wsl.onWebsocketContinuation( this, f );
+					continue;
 				} else if( !fin || curop == Opcode.CONTINUOUS ) {
 					if( curop != Opcode.CONTINUOUS ) {
 						if( current_continuous_frame_opcode != null )

--- a/src/main/java/org/java_websocket/WebSocketListener.java
+++ b/src/main/java/org/java_websocket/WebSocketListener.java
@@ -137,6 +137,11 @@ public interface WebSocketListener {
 	public void onWebsocketPong( WebSocket conn, Framedata f );
 
 	/**
+	 * Called when a continuation frame is received (in response to a from-client-to-server PING - yes, NOT PONG!).
+	 **/
+	public void onWebsocketContinuation( WebSocket conn, Framedata f );
+
+	/**
 	 * Gets the XML string that should be returned if a client requests a Flash
 	 * security policy.
 	 * @throws InvalidDataException thrown when some data that is required to generate the flash-policy like the websocket local port could not be obtained.

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -299,6 +299,10 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 	}
 
 	@Override
+	public void onWebsocketContinuation( WebSocket conn, Framedata f ) {
+	}
+
+	@Override
 	public void onWebsocketCloseInitiated( WebSocket conn, int code, String reason ) {
 		onCloseInitiated( code, reason );
 	}

--- a/src/main/java/org/java_websocket/drafts/Draft_10.java
+++ b/src/main/java/org/java_websocket/drafts/Draft_10.java
@@ -304,12 +304,13 @@ public class Draft_10 extends Draft {
 		byte b1 = buffer.get( /*0*/);
 		boolean FIN = b1 >> 8 != 0;
 		byte rsv = (byte) ( ( b1 & ~(byte) 128 ) >> 4 );
-		if( rsv != 0 )
-			throw new InvalidFrameException( "bad rsv " + rsv );
+		boolean isContinuation = rsv != 0;
+//		if( rsv != 0 )
+//			throw new InvalidFrameException( "bad rsv " + rsv );
 		byte b2 = buffer.get( /*1*/);
 		boolean MASK = ( b2 & -128 ) != 0;
 		int payloadlength = (byte) ( b2 & ~(byte) 128 );
-		Opcode optcode = toOpcode( (byte) ( b1 & 15 ) );
+		Opcode optcode = isContinuation ? Opcode.CONTINUATION : toOpcode( (byte) ( b1 & 15 ) );
 
 		if( !FIN ) {
 			if( optcode == Opcode.PING || optcode == Opcode.PONG || optcode == Opcode.CLOSING ) {

--- a/src/main/java/org/java_websocket/framing/Framedata.java
+++ b/src/main/java/org/java_websocket/framing/Framedata.java
@@ -6,7 +6,7 @@ import org.java_websocket.exceptions.InvalidFrameException;
 
 public interface Framedata {
 	public enum Opcode {
-		CONTINUOUS, TEXT, BINARY, PING, PONG, CLOSING
+		CONTINUOUS, TEXT, BINARY, PING, PONG, CLOSING, CONTINUATION
 		// more to come
 	}
 	public boolean isFin();

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -577,6 +577,10 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 	}
 
 	@Override
+	public void onWebsocketContinuation( WebSocket conn, Framedata f ) {
+	}
+
+	@Override
 	public void onWebsocketCloseInitiated( WebSocket conn, int code, String reason ) {
 		onCloseInitiated( conn, code, reason );
 	}
@@ -584,7 +588,6 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 	@Override
 	public void onWebsocketClosing( WebSocket conn, int code, String reason, boolean remote ) {
 		onClosing( conn, code, reason, remote );
-
 	}
 
 	public void onCloseInitiated( WebSocket conn, int code, String reason ) {


### PR DESCRIPTION
… (yes, not PONG), work; `.Net`'s `System.ServiceModel.WebSockets.WebSocket` client will by default send a PING to the server every 50 seconds

Corresponding issue: https://github.com/TooTallNate/Java-WebSocket/issues/392
Absent this pull request, the following exception will be thrown upon the server continuation frame:

```
2016/05/17 08:32:01.951,E,Thread-0,WebSocketHandler.java(113) [Main.onError],onError
org.java_websocket.exceptions.InvalidFrameException: bad rsv 1
        at org.java_websocket.drafts.Draft_10.translateSingleFrame(Draft_10.java:309) ~[Java-WebSocket-1.3.0.jar:na]
        at org.java_websocket.drafts.Draft_10.translateFrame(Draft_10.java:286) ~[Java-WebSocket-1.3.0.jar:na]
        at org.java_websocket.WebSocketImpl.decodeFrames(WebSocketImpl.java:312) [Java-WebSocket-1.3.0.jar:na]
        at org.java_websocket.WebSocketImpl.decode(WebSocketImpl.java:157) [Java-WebSocket-1.3.0.jar:na]
        at org.java_websocket.client.WebSocketClient.interruptableRun(WebSocketClient.java:230) [Java-WebSocket-1.3.0.jar:na]
        at org.java_websocket.client.WebSocketClient.run(WebSocketClient.java:188) [Java-WebSocket-1.3.0.jar:na]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_91]

```

I'm not sure if this is conforming to WebSocket standards, but this is what (one of the many) official MS WebSocket client implementation does by default: sending PINGs to the server.

Attached are screenshots of the 3 TCP frames that make up such a client initiated heartbeat exchange

![ms-1-client-server-ping](https://cloud.githubusercontent.com/assets/1841686/15313183/a1f7e5d8-1c44-11e6-9433-c781254affd2.png)
![ms-2-server-client-continuation](https://cloud.githubusercontent.com/assets/1841686/15313189/abfd638c-1c44-11e6-9409-964a4b962149.png)
![ms-3-client-server-tcp-ack](https://cloud.githubusercontent.com/assets/1841686/15313192/b12b4c52-1c44-11e6-939c-7a11718530a4.png)
