### PR TITLE
Close WebSocketServer's selector to free socket (#272) (#1)

### DIFF
--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -409,6 +409,13 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 					w.interrupt();
 				}
 			}
+			if( selector != null ) {
+				try {
+					selector.close();
+				} catch ( IOException e ) {
+					onError( null, e );
+				}
+			}
 			if( server != null ) {
 				try {
 					server.close();


### PR DESCRIPTION
close the selector when the WebSocketServer's selectorthread is
finishing. This allows the port to be freed on stop() and another
instance to bind on the same port