### PR TITLE
Set channel.StandardSocketOptions.TCP_NODELAY to true

### DIFF
--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -1,5 +1,6 @@
 package org.java_websocket.server;
 
+import java.net.StandardSocketOptions;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -334,6 +335,7 @@ public abstract class WebSocketServer extends WebSocketAdapter implements Runnab
 							if(channel==null){
 								continue;
 							}
+							channel.setOption(StandardSocketOptions.TCP_NODELAY, new Boolean(true));
 							channel.configureBlocking( false );
 							WebSocketImpl w = wsf.createWebSocket( this, drafts, channel.socket() );
 							w.key = channel.register( selector, SelectionKey.OP_READ, w );


### PR DESCRIPTION
I was having trouble with latency ranging from 30ms to 150ms.  Setting TCP_NODELAY improved latency and it now ranges between 30 to 50ms.  I'm not sure if having this be true for everyone is a good idea.