### PR TITLE
Give the main WebSocketClient thread a name

### DIFF
--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -157,7 +157,7 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 	public void connect() {
 		if( writeThread != null )
 			throw new IllegalStateException( "WebSocketClient objects are not reuseable" );
-		writeThread = new Thread( this );
+		writeThread = new Thread( this, "WebsocketMainThread" );
 		writeThread.start();
 	}
 


### PR DESCRIPTION
Only the read thread is assigned a name in a WebSocketClient instance.  The main Runnable acquires a default name like "Thread-7".  I'm working on an application where I need to identify threads and manage them, and it would be nice to be able to distinguish them purely by name instead of inspecting their stack trace.  This modification gives the unnamed thread the identifier "WebsocketMainThread".  