### PR TITLE
Recieving no handshake from the endpoint should not cause a server shutdown

### DIFF
--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -593,6 +593,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 	 * @return Removing connection successful
 	 */
 	protected boolean removeConnection( WebSocket ws ) {
+		boolean removed = false;
 		synchronized ( connections ) {
 			if (this.connections.contains( ws )) {
 				removed = this.connections.remove( ws );

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -593,10 +593,15 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 	 * @return Removing connection successful
 	 */
 	protected boolean removeConnection( WebSocket ws ) {
-		boolean removed;
 		synchronized ( connections ) {
-			removed = this.connections.remove( ws );
-			assert ( removed );
+			if (this.connections.contains( ws )) {
+				removed = this.connections.remove( ws );
+			} else {
+				//Don't throw an assert error if the ws is not in the list. e.g. when the other endpoint did not send any handshake. see #512
+				if (WebSocketImpl.DEBUG) {
+					System.out.println("Removing connection which is not in the connections collection! Possible no handshake recieved! " + ws);
+				}
+			}
 		}
 		if( isclosed.get() && connections.size() == 0 ) {
 			selectorthread.interrupt();


### PR DESCRIPTION
If an endpoint is not sending a handshake and then closing the
connection, this should not cause an AssertError resulting in a server
shutdown. See #512