### PR TITLE
some websocket server would check the handshake request origin.So the…

### DIFF
--- a/src/main/java/org/java_websocket/drafts/Draft_6455.java
+++ b/src/main/java/org/java_websocket/drafts/Draft_6455.java
@@ -147,6 +147,7 @@ public class Draft_6455 extends Draft_17 {
 		if( requestedExtensions.length() != 0 ) {
 			request.put( "Sec-WebSocket-Extensions", requestedExtensions.toString() );
 		}
+		request.put("origin", request.getFieldValue("host"));
 		return request;
 	}
 


### PR DESCRIPTION
… request head need origin value。

For example the webrtc candidate server. url:wss://apprtc-ws.webrtc.org:443/ws