### PR TITLE
Chat server high cpu usage

### DIFF
--- a/src/main/example/ChatServer.java
+++ b/src/main/example/ChatServer.java
@@ -91,9 +91,7 @@ public class ChatServer extends WebSocketServer {
 				s.stop();
 				break;
 			}
-			//if there is no sleep
-			//, there will be about 20% cpu usage(4 cpu threads) without any websocket client connections
-			//, then some people will give up this websocket server solution.
+			
 			Thread.sleep(1000);
 		}
 	}

--- a/src/main/example/ChatServer.java
+++ b/src/main/example/ChatServer.java
@@ -91,6 +91,10 @@ public class ChatServer extends WebSocketServer {
 				s.stop();
 				break;
 			}
+			//if there is no sleep
+			//, there will be about 20% cpu usage(4 cpu threads) without any websocket client connections
+			//, then some people will give up this websocket server solution.
+			Thread.sleep(1000);
 		}
 	}
 	@Override


### PR DESCRIPTION
If there is no sleep, there will be about 20% cpu usage(4 cpu threads) without any websocket client connections, then some people will give up this websocket server solution.
I think that most of people create there websocket server from this example. When I got a 20% cpu usage, I want to give up this solution for a short time. But when I use jstack to analysis the code, I found this problem. After this fix, the cpu usage is down to 0-1% when there is no connection.