### PR TITLE
fix ChatServer broadcast error when some clients Interrupted

### DIFF
--- a/src/main/example/ChatServer.java
+++ b/src/main/example/ChatServer.java
@@ -118,7 +118,14 @@ public class ChatServer extends WebSocketServer {
 		Collection<WebSocket> con = connections();
 		synchronized ( con ) {
 			for( WebSocket c : con ) {
-				c.send( text );
+				if (c != null) {
+					try {
+						c.send(text);
+					} catch(WebsocketNotConnectedException wncException) {
+						if (WebSocketImpl.DEBUG == true)
+							System.out.println("The client is disconnected now.");
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
ChatServer broadcast will stop when some clients Interrupted with some unknown errors, then other clients can not receive the broadcast message.