### PR TITLE
Fix duplicate call of flushAndClose() if status code is PROTOCOL_ERROR on close() method.

### DIFF
--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -447,11 +447,11 @@ public class WebSocketImpl implements WebSocket {
 			} else if( code == CloseFrame.FLASHPOLICY ) {
 				assert ( remote );
 				flushAndClose( CloseFrame.FLASHPOLICY, message, true );
+			} else if( code == CloseFrame.PROTOCOL_ERROR ) { // this endpoint found a PROTOCOL_ERROR
+				flushAndClose( code, message, remote );
 			} else {
 				flushAndClose( CloseFrame.NEVER_CONNECTED, message, false );
 			}
-			if( code == CloseFrame.PROTOCOL_ERROR )// this endpoint found a PROTOCOL_ERROR
-				flushAndClose( code, message, remote );
 			readystate = READYSTATE.CLOSING;
 			tmpHandshakeBytes = null;
 			return;


### PR DESCRIPTION
This pull request fixes what seems to be a bug. 

If the handshake is refused when establishing connection with server, `flushAndClose()` is called twice, first with `CloseFrame.NEVER_CONNECTED`, then with `CloseFrame.PROTOCOL_ERROR`.