### PR TITLE
Refactoring and improved onClose behaviour

### DIFF
--- a/src/main/java/org/java_websocket/framing/CloseFrame.java
+++ b/src/main/java/org/java_websocket/framing/CloseFrame.java
@@ -210,7 +210,7 @@ public class CloseFrame extends ControlFrame {
     public void isValid() throws InvalidDataException {
         super.isValid();
         if (code == CloseFrame.NO_UTF8 && reason == null) {
-        	throw new InvalidDataException( CloseFrame.NO_UTF8 );
+        	throw new InvalidDataException( CloseFrame.NO_UTF8, "Received text is no valid utf8 string!");
 		}
         if (code == CloseFrame.NOCODE && 0 < reason.length()) {
             throw new InvalidDataException(PROTOCOL_ERROR, "A close frame must have a closecode if it has a reason");

--- a/src/main/java/org/java_websocket/framing/TextFrame.java
+++ b/src/main/java/org/java_websocket/framing/TextFrame.java
@@ -44,7 +44,7 @@ public class TextFrame extends DataFrame {
     public void isValid() throws InvalidDataException {
         super.isValid();
         if (!Charsetfunctions.isValidUTF8( getPayloadData() )) {
-            throw new InvalidDataException(CloseFrame.NO_UTF8);
+            throw new InvalidDataException(CloseFrame.NO_UTF8, "Received text is no valid utf8 string!");
         }
     }
 }


### PR DESCRIPTION
## Description
Refactoring in WebSocketImpl so the getter/setter for readyState are now used
onClose will not have null as a reason any more for no valid utf8-strings

## Related Issue
#577 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bugfix and code cleanups

## How Has This Been Tested?
Test suite

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.