### PR TITLE
 Check if connection is open on sendPing &  change readystate on closeConnection 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ bin
 *.xml
 .idea/.name
 *.jks
+lib/junit-4.7.jar
+*.jar

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+pipeline { agent { docker { image 'maven:3-alpine' args '-v /root/.m2:/root/.m2' } } stages { stage('Build') { steps { sh 'mvn -B -DskipTests clean package' } } stage('Test') { steps { sh 'mvn test' } post { always { junit 'target/surefire-reports/*.xml' } } } } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,30 @@
-pipeline { agent { docker { image 'maven:3-alpine' args '-v /root/.m2:/root/.m2' } } stages { stage('Build') { steps { sh 'mvn -B -DskipTests clean package' } } stage('Test') { steps { sh 'mvn test' } post { always { junit 'target/surefire-reports/*.xml' } } } } }
+node {
+   def mvnHome
+   stage('Preparation') { // for display purposes
+      // Get some code from a GitHub repository
+      git 'https://github.com/marci4/Java-WebSocket-Dev.git'
+      // Get the Maven tool.
+      // ** NOTE: This 'M3' Maven tool must be configured
+      // **       in the global configuration.           
+      mvnHome = tool 'M3'
+   }
+   stage('Build') {
+      // Run the maven build
+      if (isUnix()) {
+         sh "'${mvnHome}/bin/mvn' -Dmaven.test.failure.ignore clean package"
+      } else {
+         bat(/"${mvnHome}\bin\mvn" -Dmaven.test.failure.ignore clean package/)
+      }
+   }
+   stage('Test') { 
+         if (isUnix()) {
+         sh "'${mvnHome}/bin/mvn' test package"
+      } else {
+         bat(/"${mvnHome}\bin\mvn" test package/)
+      }
+   }
+   stage('Results') {
+      junit '**/target/surefire-reports/TEST-*.xml'
+      archive 'target/*.jar'
+   }
+}

--- a/src/main/java/org/java_websocket/AbstractWebSocket.java
+++ b/src/main/java/org/java_websocket/AbstractWebSocket.java
@@ -137,6 +137,7 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
 						if( webSocketImpl.getLastPong() < current ) {
 							if (WebSocketImpl.DEBUG)
 								System.out.println("Closing connection due to no pong received: " + conn.toString());
+							webSocketImpl.close( CloseFrame.ABNORMAL_CLOSE , "Closing connection due to no pong received", false );
 							webSocketImpl.closeConnection( CloseFrame.ABNORMAL_CLOSE , false );
 						} else {
 							if (webSocketImpl.isOpen()) {

--- a/src/main/java/org/java_websocket/AbstractWebSocket.java
+++ b/src/main/java/org/java_websocket/AbstractWebSocket.java
@@ -137,7 +137,6 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
 						if( webSocketImpl.getLastPong() < current ) {
 							if (WebSocketImpl.DEBUG)
 								System.out.println("Closing connection due to no pong received: " + conn.toString());
-							webSocketImpl.close( CloseFrame.ABNORMAL_CLOSE , "Closing connection due to no pong received", false );
 							webSocketImpl.closeConnection( CloseFrame.ABNORMAL_CLOSE , false );
 						} else {
 							if (webSocketImpl.isOpen()) {

--- a/src/main/java/org/java_websocket/AbstractWebSocket.java
+++ b/src/main/java/org/java_websocket/AbstractWebSocket.java
@@ -139,7 +139,12 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
 								System.out.println("Closing connection due to no pong received: " + conn.toString());
 							webSocketImpl.closeConnection( CloseFrame.ABNORMAL_CLOSE , false );
 						} else {
-							webSocketImpl.sendPing();
+							if (webSocketImpl.isOpen()) {
+								webSocketImpl.sendPing();
+							} else {
+								if (WebSocketImpl.DEBUG)
+									System.out.println("Trying to ping a non open connection: " + conn.toString());
+							}
 						}
 					}
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Check in the timertask to make sure that a connection is really open.
closeConnection() can also adjust the readystate to closing, if the closecode is CloseFrame.Abnormal_Close and the connection is still open

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#606 
#609

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#606 caused an exception
#609 just looked messy. But was no real problem due to closeConnection() changing the readystate to closed at the end

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested against demo project. Waiting for user feedback

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
