### PR TITLE
Added setAttachment and getAttachment to WebSocket interface

### DIFF
--- a/src/main/java/org/java_websocket/WebSocket.java
+++ b/src/main/java/org/java_websocket/WebSocket.java
@@ -226,6 +226,7 @@ public interface WebSocket {
 	 * The attachment may be of any type.
 	 * 
 	 * @param attachment The object to be attached to the user
+	 * @since 1.3.7
 	 **/
 	<T> void setAttachment(T attachment);
 
@@ -233,6 +234,7 @@ public interface WebSocket {
 	 * Getter for the connection attachment.
 	 * 
 	 * @return Returns the user attachment
+	 * @since 1.3.7
 	 **/
 	<T> T getAttachment();
 }

--- a/src/main/java/org/java_websocket/WebSocket.java
+++ b/src/main/java/org/java_websocket/WebSocket.java
@@ -220,4 +220,19 @@ public interface WebSocket {
 	 * @return Returns the decoded path component of this URI.
 	 **/
 	String getResourceDescriptor();
+
+	/**
+	 * Setter for an attachment on the socket connection.
+	 * The attachment may be of any type.
+	 * 
+	 * @param attachment The object to be attached to the user
+	 **/
+	<T> void setAttachment(T attachment);
+
+	/**
+	 * Getter for the connection attachment.
+	 * 
+	 * @return Returns the user attachment
+	 **/
+	<T> T getAttachment();
 }

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -146,6 +146,11 @@ public class WebSocketImpl implements WebSocket {
 	private PingFrame pingFrame;
 
 	/**
+	 * Attribute to store connection attachment
+	 */
+	private Object attachment;
+
+	/**
 	 * Creates a websocket with server role
 	 *
 	 * @param listener The listener for this instance
@@ -797,6 +802,17 @@ public class WebSocketImpl implements WebSocket {
 	 */
 	public WebSocketListener getWebSocketListener() {
 		return wsl;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T getAttachment() {
+		return (T) attachment;
+	}
+
+	@Override
+	public <T> void setAttachment(T attachment) {
+		this.attachment = attachment;
 	}
 
 }

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -147,6 +147,7 @@ public class WebSocketImpl implements WebSocket {
 
 	/**
 	 * Attribute to store connection attachment
+	 * @since 1.3.7
 	 */
 	private Object attachment;
 


### PR DESCRIPTION
## Description
This allows a WebSocket connection object to have any kind of data associated.
You can now store information of each connection/user and access it when `onMessage` or `onClose` is fired.

#### Usage example
```java
public void onOpen(WebSocket conn, ClientHandshake handshake) {
    User user = new User(conn);
    conn.setAttachment(user);
}

public void onMessage(WebSocket conn, String message) {
    User user = conn.getAttachment();
    // ...
}
```


## Related Issue
#485 _Create key/value map in WebSocket_

## Motivation and Context
I need to store information about each connection, id, name, etc.
I started by open an issue, then @marci4 replied there was an open discussion about my problem here: #485. After reading all it was said about a possible implementation, I did some performance tests between implementing an `HashMap` or creating a getter and a setter to an attachment of type `<T>`, and this one was the most efficient by far, with tens and billions of elements.

## How Has This Been Tested?
I'm using this feature now, and it's working great. I have a `User.java` that I use as the connection attachment, with many variables and some logic, everything is working as expected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
