### PR TITLE
WebSocketClient supports reconnecting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,14 @@
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>1.6</source>
+                <target>1.6</target>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/src/main/example/ReconnectClientExample.java
+++ b/src/main/example/ReconnectClientExample.java
@@ -23,20 +23,33 @@
  *  OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package org.java_websocket.issues;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.java_websocket.WebSocketImpl;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-		org.java_websocket.issues.Issue609Test.class,
-		org.java_websocket.issues.Issue621Test.class,
-		org.java_websocket.issues.Issue580Test.class,
-		org.java_websocket.issues.Issue256Test.class
-})
 /**
- * Start all tests for issues
+ * Simple example to reconnect blocking and non-blocking.
  */
-public class AllIssueTests {
+public class ReconnectClientExample {
+	public static void main( String[] args ) throws URISyntaxException, InterruptedException {
+		WebSocketImpl.DEBUG = true;
+		ExampleClient c = new ExampleClient( new URI( "ws://localhost:8887" ) );
+		//Connect to a server normally
+		c.connectBlocking();
+		c.send( "hi" );
+		Thread.sleep( 10 );
+		c.closeBlocking();
+		//Disconnect manually and reconnect blocking
+		c.reconnectBlocking();
+		c.send( "it's" );
+		Thread.sleep( 10000 );
+		c.closeBlocking();
+		//Disconnect manually and reconnect
+		c.reconnect();
+		Thread.sleep( 100 );
+		c.send( "me" );
+		Thread.sleep( 100 );
+		c.closeBlocking();
+	}
 }

--- a/src/test/java/org/java_websocket/issues/Issue256Test.java
+++ b/src/test/java/org/java_websocket/issues/Issue256Test.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2010-2018 Nathan Rajlich
+ *
+ *  Permission is hereby granted, free of charge, to any person
+ *  obtaining a copy of this software and associated documentation
+ *  files (the "Software"), to deal in the Software without
+ *  restriction, including without limitation the rights to use,
+ *  copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following
+ *  conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.java_websocket.issues;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.WebSocketImpl;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.handshake.ServerHandshake;
+import org.java_websocket.server.WebSocketServer;
+import org.java_websocket.util.SocketUtil;
+import org.java_websocket.util.ThreadCheck;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+
+public class Issue256Test {
+
+	@Rule
+	public ThreadCheck zombies = new ThreadCheck();
+
+	private void runTestScenarioReconnect(boolean reconnectBlocking) throws Exception {
+		final CountDownLatch countServerDownLatch = new CountDownLatch( 1 );
+		int port = SocketUtil.getAvailablePort();
+		WebSocketServer ws = new WebSocketServer( new InetSocketAddress( port ) ) {
+			@Override
+			public void onOpen( WebSocket conn, ClientHandshake handshake ) {
+
+			}
+
+			@Override
+			public void onClose( WebSocket conn, int code, String reason, boolean remote ) {
+
+			}
+
+			@Override
+			public void onMessage( WebSocket conn, String message ) {
+
+			}
+
+			@Override
+			public void onError( WebSocket conn, Exception ex ) {
+
+			}
+
+			@Override
+			public void onStart() {
+				countServerDownLatch.countDown();
+			}
+		};
+		ws.start();
+		countServerDownLatch.await();
+		WebSocketClient clt = new WebSocketClient( new URI( "ws://localhost:" + port ) ) {
+			@Override
+			public void onOpen( ServerHandshake handshakedata ) {
+
+			}
+
+			@Override
+			public void onMessage( String message ) {
+
+			}
+
+			@Override
+			public void onClose( int code, String reason, boolean remote ) {
+
+			}
+
+			@Override
+			public void onError( Exception ex ) {
+
+			}
+		};
+		clt.connectBlocking();
+		clt.send("test");
+		clt.getSocket().close();
+		if (reconnectBlocking) {
+			clt.reconnectBlocking();
+		} else {
+			clt.reconnect();
+		}
+		Thread.sleep( 100 );
+
+		ws.stop();
+		Thread.sleep( 100 );
+	}
+
+	@Test
+	public void runReconnectBlockingScenario0() throws Exception {
+		runTestScenarioReconnect(true);
+	}
+	@Test
+	public void runReconnectBlockingScenario1() throws Exception {
+		runTestScenarioReconnect(true);
+	}
+	@Test
+	public void runReconnectBlockingScenario2() throws Exception {
+		runTestScenarioReconnect(true);
+	}
+	@Test
+	public void runReconnectBlockingScenario3() throws Exception {
+		runTestScenarioReconnect(true);
+	}
+	@Test
+	public void runReconnectBlockingScenario4() throws Exception {
+		runTestScenarioReconnect(true);
+	}
+	@Test
+	public void runReconnectBlockingScenario5() throws Exception {
+		runTestScenarioReconnect(true);
+	}
+	@Test
+	public void runReconnectBlockingScenario6() throws Exception {
+		runTestScenarioReconnect(true);
+	}
+	@Test
+	public void runReconnectBlockingScenario7() throws Exception {
+		runTestScenarioReconnect(true);
+	}
+	@Test
+	public void runReconnectBlockingScenario8() throws Exception {
+		runTestScenarioReconnect(true);
+	}
+	@Test
+	public void runReconnectBlockingScenario9() throws Exception {
+		runTestScenarioReconnect(true);
+	}
+
+	@Test
+	public void runReconnectScenario0() throws Exception {
+		runTestScenarioReconnect(false);
+	}
+	@Test
+	public void runReconnectScenario1() throws Exception {
+		runTestScenarioReconnect(false);
+	}
+	@Test
+	public void runReconnectScenario2() throws Exception {
+		runTestScenarioReconnect(false);
+	}
+	@Test
+	public void runReconnectScenario3() throws Exception {
+		runTestScenarioReconnect(false);
+	}
+	@Test
+	public void runReconnectScenario4() throws Exception {
+		runTestScenarioReconnect(false);
+	}
+	@Test
+	public void runReconnectScenario5() throws Exception {
+		runTestScenarioReconnect(false);
+	}
+	@Test
+	public void runReconnectScenario6() throws Exception {
+		runTestScenarioReconnect(false);
+	}
+	@Test
+	public void runReconnectScenario7() throws Exception {
+		runTestScenarioReconnect(false);
+	}
+	@Test
+	public void runReconnectScenario8() throws Exception {
+		runTestScenarioReconnect(false);
+	}
+	@Test
+	public void runReconnectScenario9() throws Exception {
+		runTestScenarioReconnect(false);
+	}
+
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added two methods, reconnect() and reconnectBlocking()
Added ReconnectExample
Reused the Test 580 for this issue to make sure no threads are left
running

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #256 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Request

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Reused Issue580 Test and used the reconnect methods

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (JavaDocs)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
