### PR TITLE
Removed assertion from WebSocketImpl.isOpen (see #694)

### DIFF
--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -716,7 +716,6 @@ public class WebSocketImpl implements WebSocket {
 
 	@Override
 	public boolean isOpen() {
-		assert ( getReadyState() != READYSTATE.OPEN || !flushandclosestate );
 		return getReadyState() == READYSTATE.OPEN;
 	}
 


### PR DESCRIPTION
Removed assertion from WebSocketImpl.isOpen()

## Related Issue
Issue #694 

## Motivation and Context
There are some situations where the assertion may be triggered from normal usage.
A getter method such as this should not throw an exception. 

## How Has This Been Tested?
The project builds correctly and examples run. I have not run the autobahn test suite.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
I doubt any of the following should apply in this case:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
