### PR TITLE
Added a broadcast method for ByteBuffers

### DIFF
--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -829,24 +829,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 		if (data == null || clients == null) {
 			throw new IllegalArgumentException();
 		}
-		Map<Draft, List<Framedata>> draftFrames = new HashMap<Draft, List<Framedata>>();
-		ByteBuffer byteBufferData = ByteBuffer.wrap( data );
-		synchronized( clients ) {
-			for( WebSocket client : clients ) {
-				if( client != null ) {
-					Draft draft = client.getDraft();
-					if( !draftFrames.containsKey( draft ) ) {
-						List<Framedata> frames = draft.createFrames( byteBufferData, false );
-						draftFrames.put( draft, frames );
-					}
-					try {
-						client.sendFrame( draftFrames.get( draft ) );
-					} catch ( WebsocketNotConnectedException e ) {
-						//Ignore this exception in this case
-					}
-				}
-			}
-		}
+		broadcast(ByteBuffer.wrap(data), clients);
 	}
 
 	/**

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -812,6 +812,10 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 		broadcast( data, connections );
 	}
 
+	/**
+	 * Send a ByteBuffer to all connected endpoints
+	 * @param data the data to send to the endpoints
+	 */
 	public void broadcast(ByteBuffer data) {
 		broadcast(data, connections);
 	}
@@ -845,6 +849,11 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 		}
 	}
 
+	/**
+	 * Send a ByteBuffer to a specific collection of websocket connections
+	 * @param data the data to send to the endpoints
+	 * @param clients a collection of endpoints to whom the text has to be send
+	 */
 	public void broadcast(ByteBuffer data, Collection<WebSocket> clients) {
 		if (data == null || clients == null) {
 			throw new IllegalArgumentException();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added two new methods to WebSocketServer: `broadcast(ByteBuffer)` and `broadcast(ByteBuffer, Collection<WebSocket>`).
Since was duplicated code, I forwarded the `broadcast(byte[])` methods to the ByteBuffer version by using `ByteBuffer.wrap`
## Related Issue
#711 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows broadcasting data from a ByteBuffer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests are passing.
I haven't added any extra tests, mostly because I have no idea where to put them (where are the old broadcast methods tested?). Whoever reviews this, please answer that. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (I have retained the code style/formatting from the fragments I've edited)
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly. 
- [ ] I have added tests to cover my changes. 
- [X] All new and existing tests passed.
