### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 group = 'org.java_websocket'
-version = '1.3.8'
+version = '1.4.0-SNAPSHOT'
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
@@ -25,6 +25,10 @@ configure(install.repositories.mavenInstaller) {
 
 dependencies {
 	deployerJars "org.apache.maven.wagon:wagon-webdav:1.0-beta-2"
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+    testCompile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+    testCompile group: 'junit', name: 'junit', version: '4.11'
+    testCompile group: 'org.json', name: 'json', version: '20180130'
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates `gradle.build` to include the new logging dependencies.

## Related Issue
https://github.com/TooTallNate/Java-WebSocket/issues/784

## Motivation and Context
Maven was updated for these dependencies, but gradle was not. I'm assuming since this project still contains a `gradle.build` file, it's meant to still support gradle.

## How Has This Been Tested?
I ran `./gradle build`. Instead of "BUILD FAILED" I see "BUILD SUCCESSFUL".

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
