### PR TITLE
Synchronize the readState field

### DIFF
--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -114,7 +114,7 @@ public class WebSocketImpl implements WebSocket {
 	/**
 	 * The current state of the connection
 	 */
-	private ReadyState readyState = ReadyState.NOT_YET_CONNECTED;
+	private volatile ReadyState readyState = ReadyState.NOT_YET_CONNECTED;
 
 	/**
 	 * A list of drafts available for this websocket


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding a key word `volatile` to avoid non thread-safe checking of `WebSocketImpl.readyState`.

## Related Issue
Checking field WebSocketImpl.readyState is non thread-safe #808