### PR TITLE
Remove outdated build instructions from README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,17 +18,7 @@ Implemented WebSocket protocol versions are:
 
 
 ## Build
-You can build using Ant, Maven, Gradle or Leiningen but there is nothing against just putting the source path ```src/main/java ``` on your applications buildpath.
-
-### Ant
-
-``` bash
-ant 
-```
-
-will create the javadoc of this library at ```doc/``` and build the library itself: ```dist/java_websocket.jar```
-
-The ant targets are: ```compile```, ```jar```, ```doc``` and ```clean```
+You can build using Maven, Gradle or Leiningen but there is nothing against just putting the source path ```src/main/java ``` on your applications buildpath.
 
 ### Maven
 To use maven add this dependency to your pom.xml:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Building with `ant` is no longer supported (de70cdc) but README still contains instructions on how to build with `ant`

## Related Issue
#819 

## Motivation and Context
Hopefully obvious

## How Has This Been Tested?
Looks fine to me

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
