### PR TITLE
SSLEngineWebSocketServerFactory allows more customization

### DIFF
--- a/src/main/example/SSLClientExample.java
+++ b/src/main/example/SSLClientExample.java
@@ -111,7 +111,9 @@ public class SSLClientExample {
 		while ( true ) {
 			String line = reader.readLine();
 			if( line.equals( "close" ) ) {
-				chatclient.close();
+				chatclient.closeBlocking();
+			} else if ( line.equals( "open" ) ) {
+				chatclient.reconnect();
 			} else {
 				chatclient.send( line );
 			}

--- a/src/main/example/TwoWaySSLServerExample.java
+++ b/src/main/example/TwoWaySSLServerExample.java
@@ -25,18 +25,15 @@
  *  OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import org.java_websocket.server.SSLEngineWebSocketServerFactory;
+import org.java_websocket.server.SSLParametersWebSocketServerFactory;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.security.KeyStore;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Copy of SSLServerExample except we use @link SSLEngineWebSocketServerFactory to customize clientMode/ClientAuth to force client to present a cert.
@@ -70,13 +67,10 @@ public class TwoWaySSLServerExample {
 		SSLContext sslContext = SSLContext.getInstance( "TLS" );
 		sslContext.init( kmf.getKeyManagers(), tmf.getTrustManagers(), null );
 
-		SSLEngine engine = sslContext.createSSLEngine();
-
-		// Here we force the client to present a certificate
-		engine.setUseClientMode(false);
-		engine.setNeedClientAuth(true);
-
-		chatserver.setWebSocketFactory( new SSLEngineWebSocketServerFactory( engine ) );
+		SSLParameters sslParameters = new SSLParameters();
+		// This is all we need
+		sslParameters.setNeedClientAuth(true);
+		chatserver.setWebSocketFactory( new SSLParametersWebSocketServerFactory(sslContext, sslParameters));
 
 		chatserver.start();
 

--- a/src/main/example/TwoWaySSLServerExample.java
+++ b/src/main/example/TwoWaySSLServerExample.java
@@ -1,0 +1,84 @@
+
+
+/*
+ * Copyright (c) 2010-2019 Nathan Rajlich
+ *
+ *  Permission is hereby granted, free of charge, to any person
+ *  obtaining a copy of this software and associated documentation
+ *  files (the "Software"), to deal in the Software without
+ *  restriction, including without limitation the rights to use,
+ *  copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following
+ *  conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import org.java_websocket.server.SSLEngineWebSocketServerFactory;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Copy of SSLServerExample except we use @link SSLEngineWebSocketServerFactory to customize clientMode/ClientAuth to force client to present a cert.
+ * Example of Two-way ssl/MutualAuthentication/ClientAuthentication
+ */
+public class TwoWaySSLServerExample {
+
+	/*
+	 * Keystore with certificate created like so (in JKS format):
+	 *
+	 *keytool -genkey -keyalg RSA -validity 3650 -keystore "keystore.jks" -storepass "storepassword" -keypass "keypassword" -alias "default" -dname "CN=127.0.0.1, OU=MyOrgUnit, O=MyOrg, L=MyCity, S=MyRegion, C=MyCountry"
+	 */
+	public static void main( String[] args ) throws Exception {
+		ChatServer chatserver = new ChatServer( 8887 ); // Firefox does allow multible ssl connection only via port 443 //tested on FF16
+
+		// load up the key store
+		String STORETYPE = "JKS";
+		String KEYSTORE = "keystore.jks";
+		String STOREPASSWORD = "storepassword";
+		String KEYPASSWORD = "keypassword";
+
+		KeyStore ks = KeyStore.getInstance( STORETYPE );
+		File kf = new File( KEYSTORE );
+		ks.load( new FileInputStream( kf ), STOREPASSWORD.toCharArray() );
+
+		KeyManagerFactory kmf = KeyManagerFactory.getInstance( "SunX509" );
+		kmf.init( ks, KEYPASSWORD.toCharArray() );
+		TrustManagerFactory tmf = TrustManagerFactory.getInstance( "SunX509" );
+		tmf.init( ks );
+
+		SSLContext sslContext = SSLContext.getInstance( "TLS" );
+		sslContext.init( kmf.getKeyManagers(), tmf.getTrustManagers(), null );
+
+		SSLEngine engine = sslContext.createSSLEngine();
+
+		// Here we force the client to present a certificate
+		engine.setUseClientMode(false);
+		engine.setNeedClientAuth(true);
+
+		chatserver.setWebSocketFactory( new SSLEngineWebSocketServerFactory( engine ) );
+
+		chatserver.start();
+
+	}
+}

--- a/src/main/java/org/java_websocket/server/SSLEngineWebSocketServerFactory.java
+++ b/src/main/java/org/java_websocket/server/SSLEngineWebSocketServerFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2010-2019 Nathan Rajlich
+ *
+ *  Permission is hereby granted, free of charge, to any person
+ *  obtaining a copy of this software and associated documentation
+ *  files (the "Software"), to deal in the Software without
+ *  restriction, including without limitation the rights to use,
+ *  copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following
+ *  conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.java_websocket.server;
+
+import org.java_websocket.SSLSocketChannel2;
+import org.java_websocket.WebSocketAdapter;
+import org.java_websocket.WebSocketImpl;
+import org.java_websocket.WebSocketServerFactory;
+import org.java_websocket.drafts.Draft;
+
+import javax.net.ssl.SSLEngine;
+import java.io.IOException;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.SocketChannel;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * WebSocketFactory that take a SSLEngine as a parameter allow for customization of SSLParameters, Cipher Suites, Supported Protocols, ClientMode, ClientAuth ...
+ * @link https://docs.oracle.com/javase/7/docs/api/javax/net/ssl/SSLEngine.html
+ */
+public class SSLEngineWebSocketServerFactory implements WebSocketServerFactory {
+
+  private final SSLEngine sslEngine;
+  protected ExecutorService exec;
+
+  public SSLEngineWebSocketServerFactory(SSLEngine sslEngine) {
+    this(sslEngine, Executors.newSingleThreadScheduledExecutor());
+  }
+
+  private SSLEngineWebSocketServerFactory(SSLEngine sslEngine, ExecutorService exec) {
+    this.sslEngine = sslEngine;
+    this.exec = exec;
+  }
+
+  @Override
+  public WebSocketImpl createWebSocket( WebSocketAdapter a, Draft d) {
+    return new WebSocketImpl( a, d );
+  }
+
+  @Override
+  public WebSocketImpl createWebSocket( WebSocketAdapter a, List<Draft> d) {
+    return new WebSocketImpl( a, d );
+  }
+
+  @Override
+  public ByteChannel wrapChannel(SocketChannel channel, SelectionKey key) throws IOException {
+    return new SSLSocketChannel2(channel, sslEngine, exec, key);
+  }
+
+  @Override
+  public void close() {
+
+  }
+}

--- a/src/main/java/org/java_websocket/server/SSLParametersWebSocketServerFactory.java
+++ b/src/main/java/org/java_websocket/server/SSLParametersWebSocketServerFactory.java
@@ -48,7 +48,7 @@ public class SSLParametersWebSocketServerFactory extends DefaultSSLWebSocketServ
    * New CustomSSLWebSocketServerFactory configured to only support given protocols and given cipher suites.
    *
    * @param sslContext          - can not be <code>null</code>
-   * @param sslParameters    - sslParameters
+   * @param sslParameters       - can not be <code>null</code>
    */
   public SSLParametersWebSocketServerFactory(SSLContext sslContext, SSLParameters sslParameters) {
     this(sslContext, Executors.newSingleThreadScheduledExecutor(), sslParameters);
@@ -59,7 +59,7 @@ public class SSLParametersWebSocketServerFactory extends DefaultSSLWebSocketServ
    *
    * @param sslContext          - can not be <code>null</code>
    * @param executerService     - can not be <code>null</code>
-   * @param sslParameters    - sslParameters
+   * @param sslParameters       - can not be <code>null</code>
    */
   public SSLParametersWebSocketServerFactory(SSLContext sslContext, ExecutorService executerService, SSLParameters sslParameters) {
     super(sslContext, executerService);
@@ -73,9 +73,7 @@ public class SSLParametersWebSocketServerFactory extends DefaultSSLWebSocketServ
   public ByteChannel wrapChannel(SocketChannel channel, SelectionKey key) throws IOException {
     SSLEngine e = sslcontext.createSSLEngine();
     e.setUseClientMode(false);
-    if (sslParameters != null) {
-      e.setSSLParameters(sslParameters);
-    }
+    e.setSSLParameters(sslParameters);
     return new SSLSocketChannel2(channel, e, exec, key);
   }
 }

--- a/src/test/java/org/java_websocket/server/SSLParametersWebSocketServerFactoryTest.java
+++ b/src/test/java/org/java_websocket/server/SSLParametersWebSocketServerFactoryTest.java
@@ -1,0 +1,131 @@
+package org.java_websocket.server;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.WebSocketAdapter;
+import org.java_websocket.WebSocketImpl;
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.drafts.Draft_6455;
+import org.java_websocket.handshake.Handshakedata;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.NotYetConnectedException;
+import java.nio.channels.SocketChannel;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class SSLParametersWebSocketServerFactoryTest {
+
+    @Test
+    public void testConstructor() throws NoSuchAlgorithmException {
+        try {
+            new SSLParametersWebSocketServerFactory(null, null);
+            fail("IllegalArgumentException should be thrown");
+        } catch (IllegalArgumentException e) {
+            // Good
+        }
+        try {
+            new SSLParametersWebSocketServerFactory(SSLContext.getDefault(), null);
+            fail("IllegalArgumentException should be thrown");
+        } catch (IllegalArgumentException e) {
+        }
+        try {
+            new SSLParametersWebSocketServerFactory(SSLContext.getDefault(), new SSLParameters());
+        } catch (IllegalArgumentException e) {
+            fail("IllegalArgumentException should not be thrown");
+        }
+        try {
+            new SSLParametersWebSocketServerFactory(SSLContext.getDefault(), Executors.newCachedThreadPool(), new SSLParameters());
+        } catch (IllegalArgumentException e) {
+            fail("IllegalArgumentException should not be thrown");
+        }
+    }
+    @Test
+    public void testCreateWebSocket() throws NoSuchAlgorithmException {
+        SSLParametersWebSocketServerFactory webSocketServerFactory = new SSLParametersWebSocketServerFactory(SSLContext.getDefault(), new SSLParameters());
+        CustomWebSocketAdapter webSocketAdapter = new CustomWebSocketAdapter();
+        WebSocketImpl webSocketImpl = webSocketServerFactory.createWebSocket(webSocketAdapter, new Draft_6455());
+        assertNotNull("webSocketImpl != null", webSocketImpl);
+        webSocketImpl = webSocketServerFactory.createWebSocket(webSocketAdapter, Collections.<Draft>singletonList(new Draft_6455()));
+        assertNotNull("webSocketImpl != null", webSocketImpl);
+    }
+
+    @Test
+    public void testWrapChannel() throws IOException, NoSuchAlgorithmException {
+        SSLParametersWebSocketServerFactory webSocketServerFactory = new SSLParametersWebSocketServerFactory(SSLContext.getDefault(), new SSLParameters());
+        SocketChannel channel =  SocketChannel.open();
+        try {
+            ByteChannel result = webSocketServerFactory.wrapChannel(channel, null);
+        } catch (NotYetConnectedException e) {
+            //We do not really connect
+        }
+        channel.close();
+    }
+
+    @Test
+    public void testClose() {
+        DefaultWebSocketServerFactory webSocketServerFactory = new DefaultWebSocketServerFactory();
+        webSocketServerFactory.close();
+    }
+
+    private static class CustomWebSocketAdapter extends WebSocketAdapter {
+        @Override
+        public void onWebsocketMessage(WebSocket conn, String message) {
+
+        }
+
+        @Override
+        public void onWebsocketMessage(WebSocket conn, ByteBuffer blob) {
+
+        }
+
+        @Override
+        public void onWebsocketOpen(WebSocket conn, Handshakedata d) {
+
+        }
+
+        @Override
+        public void onWebsocketClose(WebSocket ws, int code, String reason, boolean remote) {
+
+        }
+
+        @Override
+        public void onWebsocketClosing(WebSocket ws, int code, String reason, boolean remote) {
+
+        }
+
+        @Override
+        public void onWebsocketCloseInitiated(WebSocket ws, int code, String reason) {
+
+        }
+
+        @Override
+        public void onWebsocketError(WebSocket conn, Exception ex) {
+
+        }
+
+        @Override
+        public void onWriteDemand(WebSocket conn) {
+
+        }
+
+        @Override
+        public InetSocketAddress getLocalSocketAddress(WebSocket conn) {
+            return null;
+        }
+
+        @Override
+        public InetSocketAddress getRemoteSocketAddress(WebSocket conn) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Introduces a new class SSLEngineWebSocketServerFactory that takes a SSLEngine as parameter allowing for more customization.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
https://github.com/TooTallNate/Java-WebSocket/issues/838
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now I can create a WebSocketServerFactory with a SSLEngine that has NeedClientAuth set to true, thus making Server request a client certificate on connect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created a TwoWaySSLServerExample(included in PR) that sets the value. Running wireshark with and without that flag set I can see a difference and the server sending a "client certificate request"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
