### PR TITLE
Pass on exit code in WebSocketClient close function - fixes bug #827

### DIFF
--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -768,7 +768,7 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 
 	@Override
 	public void close( int code ) {
-		engine.close();
+		engine.close( code );
 	}
 
 	@Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In the class WebSocketClient in the close function, I passed the "code" argument on to the "close" call of the WebSocketImpl "engine".


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This bug was mentioned in #827.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixes a bug where the originally supplied CloseFrame code was ignored and the CloseFrame.NORMAL code was passed on instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All the existing unit tests passed. I manually looked at the implementations of the close function and at the usages of the code argument and came to the conclusion that this change shouldn't have introduced a new issue.
This admittedly small amount of testing should suffice since this is only a minor bug fix that utilises existing functions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
