### PR TITLE
Fix issue #834 by starting WebSocketWorker of the WebSocketServer in the start function

### DIFF
--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -211,7 +211,6 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 		for( int i = 0 ; i < decodercount ; i++ ) {
 			WebSocketWorker ex = new WebSocketWorker();
 			decoders.add( ex );
-			ex.start();
 		}
 	}
 
@@ -229,6 +228,10 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 		if( selectorthread != null )
 			throw new IllegalStateException( getClass().getName() + " can only be started once." );
 		new Thread( this ).start();
+
+		for( WebSocketWorker ex : decoders ){
+			ex.start();
+		}
 	}
 
 	/**

--- a/src/test/java/org/java_websocket/issues/AllIssueTests.java
+++ b/src/test/java/org/java_websocket/issues/AllIssueTests.java
@@ -41,7 +41,8 @@ import org.junit.runners.Suite;
 		org.java_websocket.issues.Issue732Test.class,
 		org.java_websocket.issues.Issue764Test.class,
 		org.java_websocket.issues.Issue765Test.class,
-		org.java_websocket.issues.Issue825Test.class
+		org.java_websocket.issues.Issue825Test.class,
+		org.java_websocket.issues.Issue834Test.class
 })
 /**
  * Start all tests for issues

--- a/src/test/java/org/java_websocket/issues/Issue834Test.java
+++ b/src/test/java/org/java_websocket/issues/Issue834Test.java
@@ -1,0 +1,50 @@
+package org.java_websocket.issues;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.server.WebSocketServer;
+import org.java_websocket.util.SocketUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Set;
+
+public class Issue834Test {
+
+    @Test(timeout = 1000)
+    public void testNoNewThreads() throws IOException {
+
+        Set<Thread> threadSet1 = Thread.getAllStackTraces().keySet();
+
+        new WebSocketServer(new InetSocketAddress(SocketUtil.getAvailablePort())) {
+            @Override
+            public void onOpen(WebSocket conn, ClientHandshake handshake) {
+            }
+
+            @Override
+            public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+            }
+
+            @Override
+            public void onMessage(WebSocket conn, String message) {
+            }
+
+            @Override
+            public void onError(WebSocket conn, Exception ex) {
+            }
+
+            @Override
+            public void onStart() {
+            }
+        };
+
+        Set<Thread> threadSet2 = Thread.getAllStackTraces().keySet();
+
+        //checks that no threads are started in the constructor
+        Assert.assertEquals(threadSet1, threadSet2);
+
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I changed the constructor of the `WebSocketServer` class to only instantiate the `WebSocketWorkers` but not start them. Now they are started in a foreach loop in the start function.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This fixes the issue #834.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now the `WebSocketWorkers` are only started when the `WebSocketServer` is started instead of when it was instantiated. These `WebSocketWorkers` run in different threads and would keep the program alive even though the `WebSocketServer` was not running but simply instantiated.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All JUnit tests passed and the gist in the issue now properly terminates since the worker threads are never started. I did not see the need for an additional JUnit test for this small fix but would happily provide one if desired.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
