### PR TITLE
 Provide a way to access the SSLSession of a websocket instance 

### DIFF
--- a/src/main/java/org/java_websocket/SSLSocketChannel.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel.java
@@ -25,6 +25,7 @@
 
 package org.java_websocket;
 
+import org.java_websocket.interfaces.ISSLChannel;
 import org.java_websocket.util.ByteBufferUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +63,7 @@ import java.util.concurrent.ExecutorService;
  *         <p>
  *         Permission for usage recieved at May 25, 2017 by Alex Karnezis
  */
-public class SSLSocketChannel implements WrappedByteChannel, ByteChannel {
+public class SSLSocketChannel implements WrappedByteChannel, ByteChannel, ISSLChannel {
 
 	/**
 	 * Logger instance
@@ -511,5 +512,10 @@ public class SSLSocketChannel implements WrappedByteChannel, ByteChannel {
 	@Override
 	public void close() throws IOException {
 		closeConnection();
+	}
+
+	@Override
+	public SSLEngine getSSLEngine() {
+		return engine;
 	}
 }

--- a/src/main/java/org/java_websocket/SSLSocketChannel2.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel2.java
@@ -24,6 +24,7 @@
  */
 package org.java_websocket;
 
+import org.java_websocket.interfaces.ISSLChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,7 @@ import java.util.concurrent.Future;
 /**
  * Implements the relevant portions of the SocketChannel interface with the SSLEngine wrapper.
  */
-public class SSLSocketChannel2 implements ByteChannel, WrappedByteChannel {
+public class SSLSocketChannel2 implements ByteChannel, WrappedByteChannel, ISSLChannel {
 
     /**
      * Logger instance
@@ -425,4 +426,8 @@ public class SSLSocketChannel2 implements ByteChannel, WrappedByteChannel {
         return socketChannel.isBlocking();
     }
 
+    @Override
+    public SSLEngine getSSLEngine() {
+        return sslEngine;
+    }
 }

--- a/src/main/java/org/java_websocket/WebSocket.java
+++ b/src/main/java/org/java_websocket/WebSocket.java
@@ -35,6 +35,8 @@ import org.java_websocket.enums.ReadyState;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
 import org.java_websocket.framing.Framedata;
 
+import javax.net.ssl.SSLEngine;
+
 public interface WebSocket {
 
 	/**
@@ -207,4 +209,19 @@ public interface WebSocket {
 	 * @since 1.3.7
 	 **/
 	<T> T getAttachment();
+
+	/**
+	 * Does this websocket use an encrypted (wss/ssl) or unencrypted (ws) connection
+	 * @return true, if the websocket does use wss and therefore has a SSLEngine
+	 * @since 1.4.1
+	 */
+	boolean hasSSLEngine();
+
+	/**
+	 * Returns the ssl engine of websocket, if ssl/wss is used for this instance.
+	 * @return the ssl engine of this websocket instance
+	 * @throws IllegalArgumentException the underlying channel does not use ssl (use hasSSLEngine() to check)
+	 * @since 1.4.1
+	 */
+	SSLEngine getSSLEngine() throws IllegalArgumentException;
 }

--- a/src/main/java/org/java_websocket/WebSocket.java
+++ b/src/main/java/org/java_websocket/WebSocket.java
@@ -35,7 +35,7 @@ import org.java_websocket.enums.ReadyState;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
 import org.java_websocket.framing.Framedata;
 
-import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
 
 public interface WebSocket {
 
@@ -212,16 +212,16 @@ public interface WebSocket {
 
 	/**
 	 * Does this websocket use an encrypted (wss/ssl) or unencrypted (ws) connection
-	 * @return true, if the websocket does use wss and therefore has a SSLEngine
+	 * @return true, if the websocket does use wss and therefore has a SSLSession
 	 * @since 1.4.1
 	 */
-	boolean hasSSLEngine();
+	boolean hasSSLSupport();
 
 	/**
-	 * Returns the ssl engine of websocket, if ssl/wss is used for this instance.
-	 * @return the ssl engine of this websocket instance
-	 * @throws IllegalArgumentException the underlying channel does not use ssl (use hasSSLEngine() to check)
+	 * Returns the ssl session of websocket, if ssl/wss is used for this instance.
+	 * @return the ssl session of this websocket instance
+	 * @throws IllegalArgumentException the underlying channel does not use ssl (use hasSSLSupport() to check)
 	 * @since 1.4.1
 	 */
-	SSLEngine getSSLEngine() throws IllegalArgumentException;
+	SSLSession getSSLSession() throws IllegalArgumentException;
 }

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -831,7 +831,7 @@ public class WebSocketImpl implements WebSocket {
 	@Override
 	public SSLSession getSSLSession() {
 		if (!hasSSLSupport()) {
-			throw new IllegalStateException("This websocket does use ws instead of wss. No SSLSession available.");
+			throw new IllegalArgumentException("This websocket uses ws instead of wss. No SSLSession available.");
 		}
 		return ((ISSLChannel) channel).getSSLEngine().getSession();
 	}

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -25,6 +25,7 @@
 
 package org.java_websocket;
 
+import org.java_websocket.interfaces.ISSLChannel;
 import org.java_websocket.drafts.Draft;
 import org.java_websocket.drafts.Draft_6455;
 import org.java_websocket.enums.*;
@@ -50,6 +51,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLEngine;
 
 /**
  * Represents one end (client or server) of a single WebSocketImpl connection.
@@ -818,6 +821,19 @@ public class WebSocketImpl implements WebSocket {
 	@SuppressWarnings("unchecked")
 	public <T> T getAttachment() {
 		return (T) attachment;
+	}
+
+	@Override
+	public boolean hasSSLEngine() {
+		return channel instanceof ISSLChannel;
+	}
+
+	@Override
+	public SSLEngine getSSLEngine() {
+		if (!hasSSLEngine()) {
+			throw new IllegalArgumentException("This websocket does use ws instead of wss. No SSLEngine available.");
+		}
+		return ((ISSLChannel) channel).getSSLEngine();
 	}
 
 	@Override

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -831,7 +831,7 @@ public class WebSocketImpl implements WebSocket {
 	@Override
 	public SSLSession getSSLSession() {
 		if (!hasSSLSupport()) {
-			throw new IllegalArgumentException("This websocket does use ws instead of wss. No SSLSession available.");
+			throw new IllegalStateException("This websocket does use ws instead of wss. No SSLSession available.");
 		}
 		return ((ISSLChannel) channel).getSSLEngine().getSession();
 	}

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -52,7 +52,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
 
 /**
  * Represents one end (client or server) of a single WebSocketImpl connection.
@@ -824,16 +824,16 @@ public class WebSocketImpl implements WebSocket {
 	}
 
 	@Override
-	public boolean hasSSLEngine() {
+	public boolean hasSSLSupport() {
 		return channel instanceof ISSLChannel;
 	}
 
 	@Override
-	public SSLEngine getSSLEngine() {
-		if (!hasSSLEngine()) {
-			throw new IllegalArgumentException("This websocket does use ws instead of wss. No SSLEngine available.");
+	public SSLSession getSSLSession() {
+		if (!hasSSLSupport()) {
+			throw new IllegalArgumentException("This websocket does use ws instead of wss. No SSLSession available.");
 		}
-		return ((ISSLChannel) channel).getSSLEngine();
+		return ((ISSLChannel) channel).getSSLEngine().getSession();
 	}
 
 	@Override

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSocketFactory;
 
@@ -850,6 +851,15 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 		return uri.getPath();
 	}
 
+	@Override
+	public boolean hasSSLEngine() {
+		return engine.hasSSLEngine();
+	}
+
+	@Override
+	public SSLEngine getSSLEngine() {
+		return engine.getSSLEngine();
+	}
 
 	/**
 	 * Method to give some additional info for specific IOExceptions

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -41,10 +41,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.SocketFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.*;
 
 import org.java_websocket.AbstractWebSocket;
 import org.java_websocket.WebSocket;
@@ -852,13 +849,13 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 	}
 
 	@Override
-	public boolean hasSSLEngine() {
-		return engine.hasSSLEngine();
+	public boolean hasSSLSupport() {
+		return engine.hasSSLSupport();
 	}
 
 	@Override
-	public SSLEngine getSSLEngine() {
-		return engine.getSSLEngine();
+	public SSLSession getSSLSession() {
+		return engine.getSSLSession();
 	}
 
 	/**

--- a/src/main/java/org/java_websocket/interfaces/ISSLChannel.java
+++ b/src/main/java/org/java_websocket/interfaces/ISSLChannel.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2019 Nathan Rajlich
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package org.java_websocket.interfaces;
+
+import javax.net.ssl.SSLEngine;
+
+/**
+ * Interface which specifies all required methods a SSLSocketChannel has to make public.
+ *
+ * @since 1.4.1
+ */
+public interface ISSLChannel {
+
+    /**
+     * Get the ssl engine used for the de- and encryption of the communication.
+     * @return the ssl engine of this channel
+     */
+    SSLEngine getSSLEngine();
+}

--- a/src/main/java/org/java_websocket/interfaces/package-info.java
+++ b/src/main/java/org/java_websocket/interfaces/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2010-2019 Nathan Rajlich
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/**
+ * This package encapsulates all new interfaces.
+ */
+package org.java_websocket.interfaces;

--- a/src/test/java/org/java_websocket/issues/Issue825Test.java
+++ b/src/test/java/org/java_websocket/issues/Issue825Test.java
@@ -32,6 +32,7 @@ import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.handshake.ServerHandshake;
 import org.java_websocket.server.DefaultSSLWebSocketServerFactory;
 import org.java_websocket.server.WebSocketServer;
+import org.java_websocket.util.SSLContextUtil;
 import org.java_websocket.util.SocketUtil;
 import org.junit.Test;
 
@@ -75,23 +76,7 @@ public class Issue825Test {
         WebSocketServer server = new MyWebSocketServer(port, countServerDownLatch, countClientDownLatch);
 
         // load up the key store
-        String STORETYPE = "JKS";
-        String KEYSTORE = String.format("src%1$stest%1$1sjava%1$1sorg%1$1sjava_websocket%1$1skeystore.jks", File.separator);
-        String STOREPASSWORD = "storepassword";
-        String KEYPASSWORD = "keypassword";
-
-        KeyStore ks = KeyStore.getInstance(STORETYPE);
-        File kf = new File(KEYSTORE);
-        ks.load(new FileInputStream(kf), STOREPASSWORD.toCharArray());
-
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
-        kmf.init(ks, KEYPASSWORD.toCharArray());
-        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
-        tmf.init(ks);
-
-        SSLContext sslContext = null;
-        sslContext = SSLContext.getInstance("TLS");
-        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        SSLContext sslContext = SSLContextUtil.getContext();
 
         server.setWebSocketFactory(new DefaultSSLWebSocketServerFactory(sslContext));
         webSocket.setSocketFactory(sslContext.getSocketFactory());

--- a/src/test/java/org/java_websocket/util/SSLContextUtil.java
+++ b/src/test/java/org/java_websocket/util/SSLContextUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2019 Nathan Rajlich
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+package org.java_websocket.util;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.security.*;
+import java.security.cert.CertificateException;
+
+public class SSLContextUtil {
+
+    public static SSLContext getContext() throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException, IOException, CertificateException, UnrecoverableKeyException {
+        // load up the key store
+        String STORETYPE = "JKS";
+        String KEYSTORE = String.format("src%1$stest%1$1sjava%1$1sorg%1$1sjava_websocket%1$1skeystore.jks", File.separator);
+        String STOREPASSWORD = "storepassword";
+        String KEYPASSWORD = "keypassword";
+
+        KeyStore ks = KeyStore.getInstance(STORETYPE);
+        File kf = new File(KEYSTORE);
+        ks.load(new FileInputStream(kf), STOREPASSWORD.toCharArray());
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+        kmf.init(ks, KEYPASSWORD.toCharArray());
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+        tmf.init(ks);
+
+        SSLContext sslContext = null;
+        sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        return sslContext;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There is currently no good way to access the SSLSession used for a websocket.
Therefore it is not possible to examine client certificates

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #890

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Clean methods to access the SSLSession.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
