### PR TITLE
Fix ConcurrentModificationException when iterating through connection…

### DIFF
--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -279,7 +279,9 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 	 * @since 1.3.8
 	 */
 	public Collection<WebSocket> getConnections() {
-		return Collections.unmodifiableCollection( new ArrayList<WebSocket>(connections) );
+		synchronized (connections) {
+			return Collections.unmodifiableCollection( new ArrayList<WebSocket>(connections) );
+		}
 	}
 
 	public InetSocketAddress getAddress() {


### PR DESCRIPTION
Fix ConcurrentModificationException when iterating through connections returned by getConnections()

## Description
<!--- Describe your changes in detail -->
Wrap **new ArrayList(connections)** in _synchronized_ to avoid ConcurrentModificationException

## Related Issue
Issue [#921](https://github.com/TooTallNate/Java-WebSocket/issues/921)
Also related to #902

## Motivation and Context
ConcurrentModificationException when looping connections and a connection is created/removed elsewhere at the same time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in production with a tight loop iterating over connections gathering statistics whilst connections are made/removed elsewhere. No more cases of ConcurrentModificationException after the fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.