### PR TITLE
Add OSGi metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.java-websocket</groupId>
     <artifactId>Java-WebSocket</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <version>1.4.0-SNAPSHOT</version>
     <name>Java-WebSocket</name>
     <description>A barebones WebSocket client and server implementation written 100% in Java</description>
@@ -39,6 +39,12 @@
                     <target>1.6</target>
                 </configuration>
             </plugin>
+            <plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>4.1.0</version>
+				<extensions>true</extensions>
+			</plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
maven-bundle-plugin added to pom.xml. This will lead to OSGi headers in the MANIFEST.MF, so the project can be used in an OSGi environment directly. No effects on non-OSGi users, no additional dependencies. 
Note: no detailed configuration of the plugin is provided, which means that all packages of the project will be exported. This is a sensible default and minimizes maintenance requirements.

## Related Issue
Fixes #822 

## Motivation and Context
support OSGi

## How Has This Been Tested?
Built locally and run in a Felix OSGi framework -> works just fine

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 -> no code changes, only added a maven plugin
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
