### PR TITLE
Fix broken link on README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -100,8 +100,7 @@ It is currently not possible to accept ws and wss connections at the same time v
 
 For some reason Firefox does not allow multiple connections to the same wss server if the server uses a different port than the default port (443).
 
-
-If you want to use `wss` on the android platfrom you should take a look at [this](http://blog.antoine.li/2010/10/22/android-trusting-ssl-certificates/).
+If you want to use `wss` on the android platfrom you should take a look at [this](https://github.com/TooTallNate/Java-WebSocket/wiki/FAQ:-Secure-WebSockets#wss-on-android).
 
 I ( @Davidiusdadi ) would be glad if you would give some feedback whether wss is working fine for you or not.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The actual link for getting information about wss on android is broken, so I'm updating it with a link from the relevant page in the wiki.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This comes to solve the #924 issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I'm fixing a link the project's README in order to help who may need information about SSL support on android.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No tests required.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
