### PR TITLE
Add ability to customize ping messages with custom data, see iss…

### DIFF
--- a/src/main/java/org/java_websocket/WebSocketAdapter.java
+++ b/src/main/java/org/java_websocket/WebSocketAdapter.java
@@ -40,6 +40,8 @@ import org.java_websocket.handshake.ServerHandshakeBuilder;
  **/
 public abstract class WebSocketAdapter implements WebSocketListener {
 
+	private PingFrame pingFrame;
+
 	/**
 	 * This default implementation does not do anything. Go ahead and overwrite it.
 	 *
@@ -84,5 +86,18 @@ public abstract class WebSocketAdapter implements WebSocketListener {
 	@Override
 	public void onWebsocketPong( WebSocket conn, Framedata f ) {
 		//To overwrite
+	}
+
+	/**
+	 * Default implementation for onPreparePing, returns a (cached) PingFrame that has no application data.
+	 *
+	 * @see org.java_websocket.WebSocketListener#onPreparePing(WebSocket)
+	 * @return PingFrame to be sent.
+	 */
+	@Override
+	public PingFrame onPreparePing(WebSocket conn) {
+		if(pingFrame == null)
+			pingFrame = new PingFrame();
+		return pingFrame;
 	}
 }

--- a/src/main/java/org/java_websocket/WebSocketAdapter.java
+++ b/src/main/java/org/java_websocket/WebSocketAdapter.java
@@ -90,8 +90,9 @@ public abstract class WebSocketAdapter implements WebSocketListener {
 
 	/**
 	 * Default implementation for onPreparePing, returns a (cached) PingFrame that has no application data.
-	 *
 	 * @see org.java_websocket.WebSocketListener#onPreparePing(WebSocket)
+	 *
+	 * @param conn The <tt>WebSocket</tt> connection from which the ping frame will be sent.
 	 * @return PingFrame to be sent.
 	 */
 	@Override

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -162,11 +162,6 @@ public class WebSocketImpl implements WebSocket {
 	private final Object synchronizeWriteObject = new Object();
 
 	/**
-	 * Attribute to cache a ping frame
-	 */
-	private PingFrame pingFrame;
-
-	/**
 	 * Attribute to store connection attachment
 	 * @since 1.3.7
 	 */
@@ -658,11 +653,12 @@ public class WebSocketImpl implements WebSocket {
 		send( Collections.singletonList( framedata ) );
 	}
 
-	public void sendPing() {
-		if( pingFrame == null ) {
-			pingFrame = new PingFrame();
-		}
-		sendFrame( pingFrame );
+	public void sendPing() throws NullPointerException {
+		// Gets a PingFrame from WebSocketListener(wsl) and sends it.
+		PingFrame pingFrame = wsl.onPreparePing(this);
+		if(pingFrame == null)
+			throw new NullPointerException("onPreparePing(WebSocket) returned null. PingFrame to sent can't be null.");
+		sendFrame(pingFrame);
 	}
 
 	@Override

--- a/src/main/java/org/java_websocket/WebSocketListener.java
+++ b/src/main/java/org/java_websocket/WebSocketListener.java
@@ -173,6 +173,7 @@ public interface WebSocketListener {
 	/**
 	 * Called just before a ping frame is sent, in order to allow users to customize their ping frame data.
 	 *
+	 * @param conn The <tt>WebSocket</tt> connection from which the ping frame will be sent.
 	 * @return PingFrame to be sent.
 	 */
 	PingFrame onPreparePing(WebSocket conn );

--- a/src/main/java/org/java_websocket/WebSocketListener.java
+++ b/src/main/java/org/java_websocket/WebSocketListener.java
@@ -32,6 +32,7 @@ import org.java_websocket.drafts.Draft;
 import org.java_websocket.exceptions.InvalidDataException;
 import org.java_websocket.framing.CloseFrame;
 import org.java_websocket.framing.Framedata;
+import org.java_websocket.framing.PingFrame;
 import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.handshake.Handshakedata;
 import org.java_websocket.handshake.ServerHandshake;
@@ -168,6 +169,13 @@ public interface WebSocketListener {
 	 * @param f The ping frame. Control frames may contain payload.
 	 */
 	void onWebsocketPing( WebSocket conn, Framedata f );
+
+	/**
+	 * Called just before a ping frame is sent, in order to allow users to customize their ping frame data.
+	 *
+	 * @return PingFrame to be sent.
+	 */
+	PingFrame onPreparePing(WebSocket conn );
 
 	/**
 	 * Called when a pong frame is received.

--- a/src/test/java/org/java_websocket/issues/Issue941Test.java
+++ b/src/test/java/org/java_websocket/issues/Issue941Test.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2010-2019 Nathan Rajlich
+ *
+ *  Permission is hereby granted, free of charge, to any person
+ *  obtaining a copy of this software and associated documentation
+ *  files (the "Software"), to deal in the Software without
+ *  restriction, including without limitation the rights to use,
+ *  copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following
+ *  conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.java_websocket.issues;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.framing.Framedata;
+import org.java_websocket.framing.PingFrame;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.handshake.ServerHandshake;
+import org.java_websocket.server.WebSocketServer;
+import org.java_websocket.util.SocketUtil;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class Issue941Test {
+
+    private CountDownLatch pingLatch = new CountDownLatch(1);
+    private CountDownLatch pongLatch = new CountDownLatch(1);
+    private byte[] pingBuffer, receivedPingBuffer, pongBuffer;
+
+    @Test
+    public void testIssue() throws Exception {
+        int port = SocketUtil.getAvailablePort();
+        WebSocketClient client = new WebSocketClient(new URI( "ws://localhost:" + port)) {
+            @Override
+            public void onOpen(ServerHandshake handshakedata) { }
+            @Override
+            public void onMessage(String message) { }
+            @Override
+            public void onClose(int code, String reason, boolean remote) { }
+            @Override
+            public void onError(Exception ex) { }
+            @Override
+            public PingFrame onPreparePing(WebSocket conn) {
+                PingFrame frame = new PingFrame();
+                pingBuffer = new byte[]{1,2,3,4,5,6,7,8,9,10};
+                frame.setPayload(ByteBuffer.wrap(pingBuffer));
+                return frame;
+            }
+            @Override
+            public void onWebsocketPong(WebSocket conn, Framedata f) {
+                pongBuffer = f.getPayloadData().array();
+                pongLatch.countDown();
+            }
+        };
+
+        WebSocketServer server = new WebSocketServer(new InetSocketAddress(port)) {
+            @Override
+            public void onOpen(WebSocket conn, ClientHandshake handshake) { }
+            @Override
+            public void onClose(WebSocket conn, int code, String reason, boolean remote) { }
+            @Override
+            public void onMessage(WebSocket conn, String message) { }
+            @Override
+            public void onError(WebSocket conn, Exception ex) { }
+            @Override
+            public void onStart() { }
+            @Override
+            public void onWebsocketPing(WebSocket conn, Framedata f) {
+                receivedPingBuffer = f.getPayloadData().array();
+                super.onWebsocketPing(conn, f);
+                pingLatch.countDown();
+            }
+        };
+
+        server.start();
+        client.connectBlocking();
+        client.setConnectionLostTimeout(1);
+        pingLatch.await();
+        assertArrayEquals(pingBuffer, receivedPingBuffer);
+        pongLatch.await();
+        assertArrayEquals(pingBuffer, pongBuffer);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a method called `onPreparePing` which provides a way for users customize their ping messages with custom data that they want to send.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Fixes #941 

## Motivation and Context
Solves the problem where users were not able to customize ping messages. In this context, customizing means filling ping messages with custom payload data.

## How Has This Been Tested?
Added a test file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
