### PR TITLE
Made loggers non-static to support deployment in containers

### DIFF
--- a/src/main/java/org/java_websocket/AbstractWebSocket.java
+++ b/src/main/java/org/java_websocket/AbstractWebSocket.java
@@ -48,7 +48,7 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
 	 *
 	 * @since 1.4.0
 	 */
-	private static final Logger log = LoggerFactory.getLogger(AbstractWebSocket.class);
+	private final Logger log = LoggerFactory.getLogger(AbstractWebSocket.class);
 
     /**
      * Attribute which allows you to deactivate the Nagle's algorithm

--- a/src/main/java/org/java_websocket/SSLSocketChannel.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel.java
@@ -70,7 +70,7 @@ public class SSLSocketChannel implements WrappedByteChannel, ByteChannel, ISSLCh
 	 *
 	 * @since 1.4.0
 	 */
-	private static final Logger log = LoggerFactory.getLogger(SSLSocketChannel.class);
+	private final Logger log = LoggerFactory.getLogger(SSLSocketChannel.class);
 
 	/**
 	 * The underlaying socket channel

--- a/src/main/java/org/java_websocket/SSLSocketChannel.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel.java
@@ -73,7 +73,7 @@ public class SSLSocketChannel implements WrappedByteChannel, ByteChannel, ISSLCh
 	private final Logger log = LoggerFactory.getLogger(SSLSocketChannel.class);
 
 	/**
-	 * The underlaying socket channel
+	 * The underlying socket channel
 	 */
 	private final SocketChannel socketChannel;
 

--- a/src/main/java/org/java_websocket/SSLSocketChannel2.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel2.java
@@ -56,16 +56,16 @@ import java.util.concurrent.Future;
 public class SSLSocketChannel2 implements ByteChannel, WrappedByteChannel, ISSLChannel {
 
     /**
+     * This object is used to feed the {@link SSLEngine}'s wrap and unwrap methods during the handshake phase.
+     **/
+    protected static ByteBuffer emptybuffer = ByteBuffer.allocate( 0 );
+
+    /**
      * Logger instance
      *
      * @since 1.4.0
      */
-    private static final Logger log = LoggerFactory.getLogger(SSLSocketChannel2.class);
-
-    /**
-     * This object is used to feed the {@link SSLEngine}'s wrap and unwrap methods during the handshake phase.
-     **/
-    protected static ByteBuffer emptybuffer = ByteBuffer.allocate( 0 );
+    private final Logger log = LoggerFactory.getLogger(SSLSocketChannel2.class);
 
     protected ExecutorService exec;
 

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -85,7 +85,7 @@ public class WebSocketImpl implements WebSocket {
 	 *
 	 * @since 1.4.0
 	 */
-	private static final Logger log = LoggerFactory.getLogger(WebSocketImpl.class);
+	private final Logger log = LoggerFactory.getLogger(WebSocketImpl.class);
 
 	/**
 	 * Queue of buffers that need to be sent to the client.

--- a/src/main/java/org/java_websocket/drafts/Draft_6455.java
+++ b/src/main/java/org/java_websocket/drafts/Draft_6455.java
@@ -86,7 +86,7 @@ public class Draft_6455 extends Draft {
 	 *
 	 * @since 1.4.0
 	 */
-	private static final Logger log = LoggerFactory.getLogger(Draft_6455.class);
+	private final Logger log = LoggerFactory.getLogger(Draft_6455.class);
 
 	/**
 	 * Attribute for the used extension in this draft

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -46,13 +46,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.java_websocket.*;
 import org.java_websocket.drafts.Draft;
-import org.java_websocket.exceptions.InvalidDataException;
 import org.java_websocket.exceptions.WebsocketNotConnectedException;
 import org.java_websocket.framing.CloseFrame;
 import org.java_websocket.framing.Framedata;
 import org.java_websocket.handshake.ClientHandshake;
 import org.java_websocket.handshake.Handshakedata;
-import org.java_websocket.handshake.ServerHandshakeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -64,14 +64,14 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class WebSocketServer extends AbstractWebSocket implements Runnable {
 
+	private static final int AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors();
+
 	/**
 	 * Logger instance
 	 *
 	 * @since 1.4.0
 	 */
-	private static final Logger log = LoggerFactory.getLogger(WebSocketServer.class);
-
-	private static final int AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors();
+	private final Logger log = LoggerFactory.getLogger(WebSocketServer.class);
 
 	/**
 	 * Holds the list of active WebSocket connections. "Active" means WebSocket


### PR DESCRIPTION
The slf4j Loggers were changed to be declared as non-static.

## Description
The slf4j Loggers were declared as `private static final`. This has been changed to `private final`.

## Related Issue
Fixes #969.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Usage of `private static final` loggers (or other classes in general) can be problematic it environments with shared classpaths and dynamic loading/unloading of JARs.

For reference see:
http://slf4j.org/faq.html#declared_static
https://cwiki.apache.org/confluence/display/COMMONS/Logging+StaticLog

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No functional changes were introduced by this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
(There were some failing tests before this change. The same ones are still failing.)