### PR TITLE
Allow user to specify max number of pending connections to a server

### DIFF
--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -109,6 +109,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 	/**
 	 * Attribute which allows you to configure the socket "backlog" parameter
 	 * which determines how many client connections can be queued.
+	 * @since 1.5.0
 	 */
 	private int maxPendingConnections = -1;
 
@@ -316,6 +317,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 	 * Set the requested maximum number of pending connections on the socket. The exact semantics are implementation
 	 * specific. The value provided should be greater than 0. If it is less than or equal to 0, then
 	 * an implementation specific default will be used. This option will be passed as "backlog" parameter to {@link ServerSocket#bind(SocketAddress, int)}
+	 * @since 1.5.0
 	 */
 	public void setMaxPendingConnections(int numberOfConnections) {
 		maxPendingConnections = numberOfConnections;
@@ -325,6 +327,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 	 * Returns the currently configured maximum number of pending connections.
 	 *
 	 * @see #setMaxPendingConnections(int)
+	 * @since 1.5.0
 	 */
 	public int getMaxPendingConnections() {
 		return maxPendingConnections;

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -26,9 +26,7 @@
 package org.java_websocket.server;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.ServerSocket;
-import java.net.Socket;
+import java.net.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.CancelledKeyException;
 import java.nio.channels.ClosedByInterruptException;
@@ -107,6 +105,12 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 	private final AtomicInteger queuesize = new AtomicInteger( 0 );
 
 	private WebSocketServerFactory wsf = new DefaultWebSocketServerFactory();
+
+	/**
+	 * Attribute which allows you to configure the socket "backlog" parameter
+	 * which determines how many client connections can be queued.
+	 */
+	private int maxPendingConnections = -1;
 
 	/**
 	 * Creates a WebSocketServer that will attempt to
@@ -308,6 +312,24 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 		return Collections.unmodifiableList( drafts );
 	}
 
+	/**
+	 * Set the requested maximum number of pending connections on the socket. The exact semantics are implementation
+	 * specific. The value provided should be greater than 0. If it is less than or equal to 0, then
+	 * an implementation specific default will be used. This option will be passed as "backlog" parameter to {@link ServerSocket#bind(SocketAddress, int)}
+	 */
+	public void setMaxPendingConnections(int numberOfConnections) {
+		maxPendingConnections = numberOfConnections;
+	}
+
+	/**
+	 * Returns the currently configured maximum number of pending connections.
+	 *
+	 * @see #setMaxPendingConnections(int)
+	 */
+	public int getMaxPendingConnections() {
+		return maxPendingConnections;
+	}
+
 	// Runnable IMPLEMENTATION /////////////////////////////////////////////////
 	public void run() {
 		if (!doEnsureSingleThread()) {
@@ -505,7 +527,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 			ServerSocket socket = server.socket();
 			socket.setReceiveBufferSize( WebSocketImpl.RCVBUF );
 			socket.setReuseAddress( isReuseAddr() );
-			socket.bind( address );
+			socket.bind( address, getMaxPendingConnections() );
 			selector = Selector.open();
 			server.register( selector, server.validOps() );
 			startConnectionLostTimer();


### PR DESCRIPTION
~~Theoretically I should add this to 1.5.0 milestone, but since this is a non-breaking change and we also have a non-breaking #1000, so maybe there should be a small 1.4.2 release so that people can use these improvements without breaking changes of 1.5.0? I will add the appropriate @​since tags to JavaDoc when this is decided.~~

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a field and two new methods to WebSocketServer: `setMaxPendingConnections(int)` and `getMaxPendingConnections()` and uses the value as a parameter when binding the server socket.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #991

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change allows users to configure the maximum number of pending connections.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests run fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
