### PR TITLE
Move setEndpointIdentificationAlgorithm inside onSetSSLParametersof

### DIFF
--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -472,8 +472,6 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 			if (socket instanceof SSLSocket) {
 				SSLSocket sslSocket = (SSLSocket)socket;
 				SSLParameters sslParameters = sslSocket.getSSLParameters();
-				// Make sure we perform hostname validation
-				sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
 				onSetSSLParameters(sslParameters);
 				sslSocket.setSSLParameters(sslParameters);
 			}
@@ -520,10 +518,14 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 
 	/**
 	 * Apply specific SSLParameters
+	 * If you override this method make sure to always call super.onSetSSLParameters() to ensure the hostname validation is active
 	 *
 	 * @param sslParameters the SSLParameters which will be used for the SSLSocket
 	 */
 	protected void onSetSSLParameters(SSLParameters sslParameters) {
+		// If you run into problem (NoSuchMethodException), check out the wiki https://github.com/TooTallNate/Java-WebSocket/wiki/No-such-method-error-'setEndpointIdentificationAlgorithm'
+		// Perform hostname validation
+		sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
 	}
 
 	/**

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -523,7 +523,7 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 	 * @param sslParameters the SSLParameters which will be used for the SSLSocket
 	 */
 	protected void onSetSSLParameters(SSLParameters sslParameters) {
-		// If you run into problem (NoSuchMethodException), check out the wiki https://github.com/TooTallNate/Java-WebSocket/wiki/No-such-method-error-'setEndpointIdentificationAlgorithm'
+		// If you run into problem on Android (NoSuchMethodException), check out the wiki https://github.com/TooTallNate/Java-WebSocket/wiki/No-such-method-error-setEndpointIdentificationAlgorithm
 		// Perform hostname validation
 		sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
 	}

--- a/src/test/java/org/java_websocket/issues/Issue997Test.java
+++ b/src/test/java/org/java_websocket/issues/Issue997Test.java
@@ -143,6 +143,8 @@ public class Issue997Test {
 
         @Override
         protected void onSetSSLParameters(SSLParameters sslParameters) {
+            // Always call super to ensure hostname validation is active by default
+            super.onSetSSLParameters(sslParameters);
             if (endpointIdentificationAlgorithm != null) {
                 sslParameters.setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Hotfix for 1.5.0
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#Fixes 1011

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Workaround for Android users
Workaround is documented in our wiki (https://github.com/TooTallNate/Java-WebSocket/wiki/No-such-method-error-'setEndpointIdentificationAlgorithm')

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Review

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
