### PR TITLE
Fix the failure of Issue256Test.

### DIFF
--- a/src/test/java/org/java_websocket/issues/Issue256Test.java
+++ b/src/test/java/org/java_websocket/issues/Issue256Test.java
@@ -96,6 +96,7 @@ public class Issue256Test {
 		};
 		ws.setConnectionLostTimeout( 0 );
 		ws.start();
+		countServerDownLatch.await();
 	}
 
 	private void runTestScenarioReconnect( boolean closeBlocking ) throws Exception {


### PR DESCRIPTION
Fix the failure of issue256Test.

Why `issue256Test` would always fail when we run the first test?
It is because we got the incompletes current thread in the method `ThreadCheck.before()`, when it went too fast so that the server's workers were not all started.
After the first test, we could got the completes current thread in the next tests because at the time the server was ready and all its workers were started. Thus, the next tests would success.