### PR TITLE
`reason` was passed to `onWebSocketClose(...)`, but was not being displayed

### DIFF
--- a/src/main/java/org/java_websocket/SSLSocketChannel.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel.java
@@ -417,7 +417,7 @@ public class SSLSocketChannel implements WrappedByteChannel, ByteChannel, ISSLCh
   }
 
   /**
-   * Compares <code>sessionProposedCapacity<code> with buffer's capacity. If buffer's capacity is
+   * Compares <code>sessionProposedCapacity</code> with buffer's capacity. If buffer's capacity is
    * smaller, returns a buffer with the proposed capacity. If it's equal or larger, returns a buffer
    * with capacity twice the size of the initial one.
    *

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -722,8 +722,9 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
   @Override
   public final void onWebsocketClose(WebSocket conn, int code, String reason, boolean remote) {
     // fix: reason display suppressed by removeConnection(conn) or onClose(...)
-	  if (reason != null)                      // added
-		log.error("Reason: " + reason);   // added
+    if (reason != null) {     
+      log.error("Reason: " + reason);  
+    }	    
     selector.wakeup();
     try {
       if (removeConnection(conn)) {

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -722,9 +722,9 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
   @Override
   public final void onWebsocketClose(WebSocket conn, int code, String reason, boolean remote) {
     // fix: reason display suppressed by removeConnection(conn) or onClose(...)
-    if (reason != null) {     
-      log.error("Reason: " + reason);  
-    }	    
+    if (reason != null) {
+      log.error("Reason: " + reason);
+    }
     selector.wakeup();
     try {
       if (removeConnection(conn)) {


### PR DESCRIPTION
`reason` was passed to `onWebsocketClose(...)` in `server\WebSocketServer`, but (under some circumstances?) was never being displayed

## Description
Added a log error line displaying `reason`

## Related Issue
Fixes #1103

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
