### PR TITLE
WebSocket.java documentation comments update

### DIFF
--- a/src/main/java/org/java_websocket/WebSocket.java
+++ b/src/main/java/org/java_websocket/WebSocket.java
@@ -137,17 +137,18 @@ public interface WebSocket {
   boolean hasBufferedData();
 
   /**
-   * Returns the address of the endpoint this socket is connected to, or{@code null} if it is
+   * Returns the address of the endpoint this socket is connected to, or {@code null} if it is
    * unconnected.
    *
-   * @return never returns null
+   * @return the remote socket address or null, if this socket is unconnected
    */
   InetSocketAddress getRemoteSocketAddress();
 
   /**
-   * Returns the address of the endpoint this socket is bound to.
+   * Returns the address of the endpoint this socket is bound to, or {@code null} if it is not
+   * bound.
    *
-   * @return never returns null
+   * @return the local socket address or null, if this socket is not bound
    */
   InetSocketAddress getLocalSocketAddress();
 


### PR DESCRIPTION
Update documentation comments for methods getRemoteSocketAddress and getLocalSocketAddress in WebSocket.java.

## Related Issue
Fixes #1108

## Motivation and Context
Fixes documentation issue mentioned in the related issue.
