### PR TITLE
Provide SSLSession in WebSocketClient

### DIFF
--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -955,12 +955,16 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 
   @Override
   public boolean hasSSLSupport() {
-    return engine.hasSSLSupport();
+    return socket instanceof SSLSocket;
   }
 
   @Override
   public SSLSession getSSLSession() {
-    return engine.getSSLSession();
+    if (!hasSSLSupport()) {
+      throw new IllegalArgumentException(
+          "This websocket uses ws instead of wss. No SSLSession available.");
+    }
+    return ((SSLSocket)socket).getSession();
   }
 
   @Override

--- a/src/test/java/org/java_websocket/issues/Issue1142Test.java
+++ b/src/test/java/org/java_websocket/issues/Issue1142Test.java
@@ -1,0 +1,138 @@
+package org.java_websocket.issues;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.concurrent.CountDownLatch;
+import javax.net.ssl.SSLContext;
+import org.java_websocket.WebSocket;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.handshake.ServerHandshake;
+import org.java_websocket.server.DefaultSSLWebSocketServerFactory;
+import org.java_websocket.server.WebSocketServer;
+import org.java_websocket.util.SSLContextUtil;
+import org.java_websocket.util.SocketUtil;
+import org.junit.Test;
+
+public class Issue1142Test {
+
+
+
+  @Test(timeout = 4000)
+  public void testWithoutSSLSession()
+      throws IOException, URISyntaxException, InterruptedException {
+    int port = SocketUtil.getAvailablePort();
+    final CountDownLatch countServerDownLatch = new CountDownLatch(1);
+    final WebSocketClient webSocket = new WebSocketClient(new URI("ws://localhost:" + port)) {
+      @Override
+      public void onOpen(ServerHandshake handshakedata) {
+        countServerDownLatch.countDown();
+      }
+
+      @Override
+      public void onMessage(String message) {
+      }
+
+      @Override
+      public void onClose(int code, String reason, boolean remote) {
+      }
+
+      @Override
+      public void onError(Exception ex) {
+      }
+    };
+    WebSocketServer server = new MyWebSocketServer(port, countServerDownLatch);
+    server.start();
+    countServerDownLatch.await();
+    webSocket.connectBlocking();
+    assertFalse(webSocket.hasSSLSupport());
+    try {
+      webSocket.getSSLSession();
+      assertFalse(false);
+    } catch (IllegalArgumentException e) {
+      // Fine
+    }
+    server.stop();
+  }
+
+  @Test(timeout = 4000)
+  public void testWithSSLSession()
+      throws IOException, URISyntaxException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException, UnrecoverableKeyException, CertificateException, InterruptedException {
+    int port = SocketUtil.getAvailablePort();
+    final CountDownLatch countServerDownLatch = new CountDownLatch(1);
+    final WebSocketClient webSocket = new WebSocketClient(new URI("wss://localhost:" + port)) {
+      @Override
+      public void onOpen(ServerHandshake handshakedata) {
+        countServerDownLatch.countDown();
+      }
+
+      @Override
+      public void onMessage(String message) {
+      }
+
+      @Override
+      public void onClose(int code, String reason, boolean remote) {
+      }
+
+      @Override
+      public void onError(Exception ex) {
+      }
+    };
+    WebSocketServer server = new MyWebSocketServer(port, countServerDownLatch);
+    SSLContext sslContext = SSLContextUtil.getContext();
+
+    server.setWebSocketFactory(new DefaultSSLWebSocketServerFactory(sslContext));
+    webSocket.setSocketFactory(sslContext.getSocketFactory());
+    server.start();
+    countServerDownLatch.await();
+    webSocket.connectBlocking();
+    assertTrue(webSocket.hasSSLSupport());
+    assertNotNull(webSocket.getSSLSession());
+    server.stop();
+  }
+
+  private static class MyWebSocketServer extends WebSocketServer {
+
+    private final CountDownLatch countServerLatch;
+
+
+    public MyWebSocketServer(int port, CountDownLatch serverDownLatch) {
+      super(new InetSocketAddress(port));
+      this.countServerLatch = serverDownLatch;
+    }
+
+    @Override
+    public void onOpen(WebSocket conn, ClientHandshake handshake) {
+    }
+
+    @Override
+    public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, String message) {
+
+    }
+
+    @Override
+    public void onError(WebSocket conn, Exception ex) {
+      ex.printStackTrace();
+    }
+
+    @Override
+    public void onStart() {
+      countServerLatch.countDown();
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added SSLSession API with #890.
This was mainly added for the WebSocketServer. Make it also available in the client.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1142

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bugfix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local test 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
