### PR TITLE
Add reverse web socket proxy implementation

### DIFF
--- a/src/main/java/org/java_websocket/reverseproxy/WebSocketReverseProxy.java
+++ b/src/main/java/org/java_websocket/reverseproxy/WebSocketReverseProxy.java
@@ -1,0 +1,90 @@
+package org.java_websocket.reverseproxy;
+
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.drafts.Draft_6455;
+import org.java_websocket.extensions.DefaultExtension;
+import org.java_websocket.extensions.IExtension;
+import org.java_websocket.protocols.IProtocol;
+import org.java_websocket.protocols.Protocol;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.logging.Logger;
+
+/**
+ *                       -----------------------------
+ *     WS CLIENT <---->  || serverSide - clientSide || <----> WS SERVER
+ *                       -----------------------------
+ */
+public class WebSocketReverseProxy implements Runnable {
+
+    private static WebSocketReverseProxyClientSide clientSide;
+    private static WebSocketReverseProxyServerSide serverSide;
+
+    private static Logger logger = Logger.getLogger(WebSocketReverseProxy.class.getName());
+
+    private String wsUrl;
+
+    private static final int SERVER_SIDE_PORT = 1234;
+    private Draft_6455 draft;
+
+    private Thread selectorThread;
+
+    public void start() {
+        if (selectorThread != null) {
+            throw new IllegalStateException(getClass().getName() + " can only be started once.");
+        }
+        new Thread(this).start();
+        selectorThread = Thread.currentThread();
+    }
+
+    public WebSocketReverseProxy(String wsUrl) {
+        this.wsUrl = wsUrl;
+    }
+
+    private void initServerSide() {
+        Protocol protocol = new Protocol("binary");
+        DefaultExtension defaultExtension = new DefaultExtension();
+        draft = new Draft_6455(Collections.<IExtension>singletonList(defaultExtension), Collections.<IProtocol>singletonList(protocol));
+        serverSide = new WebSocketReverseProxyServerSide(SERVER_SIDE_PORT, this, Collections.<Draft>singletonList(draft));
+        serverSide.start();
+        logger.info("[REVERSE-PROXY] Server side started on port " + SERVER_SIDE_PORT);
+    }
+
+    @Override
+    public void run() {
+        initServerSide();
+        boolean interrupted = false;
+        while (!interrupted) {
+            interrupted = selectorThread.isInterrupted();
+        }
+    }
+
+    public void initClientSide() throws URISyntaxException {
+        URI uri = new URI(wsUrl);
+        clientSide = new WebSocketReverseProxyClientSide(uri, this, draft);
+        clientSide.connect();
+        logger.info("[REVERSE-PROXY] Client side connected to " + wsUrl);
+    }
+
+    public void proxyMsgServerToClientSide(ByteBuffer msg) {
+        try {
+            if (clientSide == null) {
+                initClientSide();
+            }
+            clientSide.receiveProxiedMsg(msg);
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void proxyMsgClientToServerSide(ByteBuffer msg) {
+        try {
+            serverSide.receiveProxiedMessage(msg);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/java_websocket/reverseproxy/WebSocketReverseProxyClientSide.java
+++ b/src/main/java/org/java_websocket/reverseproxy/WebSocketReverseProxyClientSide.java
@@ -1,0 +1,82 @@
+package org.java_websocket.reverseproxy;
+
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.drafts.Draft_6455;
+import org.java_websocket.handshake.ServerHandshake;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.logging.Logger;
+
+public class WebSocketReverseProxyClientSide extends WebSocketClient {
+
+    private static Logger logger = Logger.getLogger(WebSocketReverseProxyClientSide.class.getName());
+    private WebSocketReverseProxy reverseProxy;
+
+    private void acceptAllCerts() {
+        TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
+            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                return new java.security.cert.X509Certificate[]{};
+            }
+            public void checkClientTrusted(X509Certificate[] chain,
+                                           String authType) throws CertificateException {
+            }
+            public void checkServerTrusted(X509Certificate[] chain,
+                                           String authType) throws CertificateException {
+            }
+        }};
+        SSLContext sc;
+        try {
+            sc = SSLContext.getInstance("TLS");
+            sc.init(null, trustAllCerts, new java.security.SecureRandom());
+            SSLSocketFactory factory = sc.getSocketFactory();
+            this.setSocketFactory(factory);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public WebSocketReverseProxyClientSide(URI wsEsxiUri, WebSocketReverseProxy reverseProxy, Draft_6455 draft) {
+        super(wsEsxiUri, draft);
+        this.reverseProxy = reverseProxy;
+        acceptAllCerts();
+    }
+
+    @Override
+    public void onOpen(ServerHandshake serverHandshake) {
+        logger.fine("[REVERSE-PROXY] [CLIENT SIDE] Open connection");
+    }
+
+    @Override
+    public void onMessage(String message) {
+        logger.fine("[REVERSE-PROXY] [CLIENT SIDE] Message: " + message);
+    }
+
+    @Override
+    public void onClose(int code, String reason, boolean remote) {
+        logger.fine("[REVERSE-PROXY] [CLIENT SIDE] Close connection: " + reason + " " + code + " " + remote);
+    }
+
+    @Override
+    public void onError(Exception ex) {
+        logger.info("[REVERSE-PROXY] [CLIENT SIDE] Error: " + ex.getLocalizedMessage());
+        ex.printStackTrace();
+    }
+
+    @Override
+    public void onMessage(ByteBuffer bytes) {
+        logger.finer("[REVERSE-PROXY] [CLIENT SIDE] Received frame, proxying to server");
+        this.reverseProxy.proxyMsgClientToServerSide(bytes);
+    }
+
+    public void receiveProxiedMsg(ByteBuffer msg) {
+        logger.finer("[REVERSE-PROXY] [CLIENT SIDE] Received proxied msg, sending to ESX host");
+        this.getConnection().send(msg);
+    }
+}

--- a/src/main/java/org/java_websocket/reverseproxy/WebSocketReverseProxyServerSide.java
+++ b/src/main/java/org/java_websocket/reverseproxy/WebSocketReverseProxyServerSide.java
@@ -1,0 +1,67 @@
+package org.java_websocket.reverseproxy;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.server.WebSocketServer;
+
+import java.net.InetSocketAddress;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.logging.Logger;
+
+public class WebSocketReverseProxyServerSide extends WebSocketServer {
+
+    private static Logger logger = Logger.getLogger(WebSocketReverseProxyServerSide.class.getName());
+    private WebSocketReverseProxy reverseProxy;
+    private WebSocket conn;
+
+    public WebSocketReverseProxyServerSide(int port, WebSocketReverseProxy reverseProxy, List<Draft> draftList) {
+        super(new InetSocketAddress(port), draftList);
+        this.reverseProxy = reverseProxy;
+    }
+
+    @Override
+    public void onOpen(WebSocket conn, ClientHandshake handshake) {
+        logger.fine("[REVERSE-PROXY] [SERVER SIDE] Open connection - client connected successfully. Starting client connection");
+        this.conn = conn;
+        try {
+            this.reverseProxy.initClientSide();
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+        logger.fine("[REVERSE-PROXY] [SERVER SIDE] Close connection: " + reason + " " + code + " " + remote);
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, String message) {
+        logger.fine("[REVERSE-PROXY] [SERVER SIDE] Message received: " + message);
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, ByteBuffer message) {
+        logger.finer("[REVERSE-PROXY] [SERVER SIDE] Proxing message to client");
+        this.reverseProxy.proxyMsgServerToClientSide(message);
+    }
+
+    @Override
+    public void onError(WebSocket conn, Exception ex) {
+        logger.fine("[REVERSE-PROXY] [SERVER SIDE] Error " + ex.getLocalizedMessage());
+        ex.printStackTrace();
+    }
+
+    @Override
+    public void onStart() {
+        logger.fine("[REVERSE-PROXY] [SERVER SIDE] Started");
+    }
+
+    public void receiveProxiedMessage(ByteBuffer msg) {
+        logger.finer("[REVERSE-PROXY] [SERVER SIDE] Sending msg to client (noVNC)");
+        conn.send(msg);
+    }
+}


### PR DESCRIPTION
## Description
Reverse web socket proxy implementation\

````
                       -----------------------------
    WS CLIENT <---->  || serverSide - clientSide || <----> WS SERVER
                       -----------------------------
 ````

## Motivation and Context
This library has been tested on CloudStack with VMware 7 hypervisors to connect to VMs console using the noVNC client. noVNC uses the websocket protocol to connect to the server that CloudStack handles. On the other end, the hypervisor server also exposes a websocket.

## How Has This Been Tested?
Tested against VMware 7 on internal lab, with noVNC as client
- Get a ticket from: https://10.10.4.165/mob/?moid=vm-6803&method=acquireTicket sending "webmks" param
- Replace the ticket variable on `TestWSReverseProxy` and start the main method
- Start noVNC and point it to: 'ws://localhost:1234'

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
