### PR TITLE
PermessageDeflate should handle uncompressed messages

### DIFF
--- a/src/test/java/org/java_websocket/example/AutobahnServerTest.java
+++ b/src/test/java/org/java_websocket/example/AutobahnServerTest.java
@@ -101,8 +101,10 @@ public class AutobahnServerTest extends WebSocketServer {
       System.out.println("No limit specified. Defaulting to MaxInteger");
       limit = Integer.MAX_VALUE;
     }
+    PerMessageDeflateExtension perMessageDeflateExtension = new PerMessageDeflateExtension();
+    perMessageDeflateExtension.setThreshold(0);
     AutobahnServerTest test = new AutobahnServerTest(port, limit,
-        new Draft_6455(new PerMessageDeflateExtension()));
+        new Draft_6455(perMessageDeflateExtension));
     test.setConnectionLostTimeout(0);
     test.start();
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
PerMessageDeflate messages may be uncompressed and should therefore not fail

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1164

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bugfix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual test was not possible since the reporter did not include an example application

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
