### PR TITLE
Added code to throttle high cpu usage.

### DIFF
--- a/src/main/java/org/java_websocket/server/HighCycleThrottler.java
+++ b/src/main/java/org/java_websocket/server/HighCycleThrottler.java
@@ -1,0 +1,69 @@
+package org.java_websocket.server;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <tt>HighCycleThrottler</tt> is a class that checks for high cycling caused by the jdk epoll selector bug.  For some
+ * reason the selector.select() code becomes not blocking causing a high CPU condition.  When this condition is detected,
+ * this class will add a 1ms delay to keep from loading up the CPU when the selector.select() code is no longer blocking.
+ *  */
+public class HighCycleThrottler
+{
+   private final Logger log = LoggerFactory.getLogger( HighCycleThrottler.class );
+   private static final int CYCLE_THRESHOLD = 600 * 60;  // 600 cycles a second for 60 seconds;
+   private final boolean  enabled;
+   private long nextCycle;
+   private long cyclesPerMinute = 0;
+   private boolean highCPUDetected = false;
+
+   public HighCycleThrottler() {
+      enabled = isEnabled( );
+      nextCycle = System.currentTimeMillis() + 60 * 1000;
+   }
+
+   /**
+    * Checks for high cycling and throttles with a 1ms delay if detected.
+    */
+   public void checkHighCycleRate() {
+      if ( enabled ) {
+         cyclesPerMinute++;
+         if ( System.currentTimeMillis() >= nextCycle ) {
+            String cycles = String.format( "Cycles last minute = %d", cyclesPerMinute );
+            log.warn( cycles );
+
+            if ( cyclesPerMinute > CYCLE_THRESHOLD ){
+             if( !highCPUDetected ){
+                  highCPUDetected = true;
+                  log.warn( "High CPU condition detected" );
+               }
+            } else if ( highCPUDetected ) {
+               log.warn( "High CPU condition cleared" );
+               highCPUDetected = false;
+            }
+
+            nextCycle = System.currentTimeMillis() + 60 * 1000;
+            cyclesPerMinute = 0;
+         }
+
+         if ( highCPUDetected ) {
+            try {
+               Thread.sleep( 1L );
+            } catch ( InterruptedException e ) {
+               log.warn( "Thread.sleep(1L) failed" );
+            }
+         }
+      }
+   }
+
+   /**
+    * Set the enabled flag and log if USE_EPOLL_SELECTOR_FIX is defined.
+    */
+   private boolean isEnabled() {
+      if (System.getenv( "USE_EPOLL_SELECTOR_FIX" ) != null){
+         log.warn( "Using EPoll Selector Fix" );
+         return true;
+      }
+      return false;
+   }
+}

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -362,6 +362,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
     if (!doSetupSelectorAndServerThread()) {
       return;
     }
+    HighCycleThrottler highCycleThrottler = new HighCycleThrottler();
     try {
       int shutdownCount = 5;
       int selectTimeout = 0;
@@ -411,6 +412,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
           // FIXME controlled shutdown (e.g. take care of buffermanagement)
           Thread.currentThread().interrupt();
         }
+        highCycleThrottler.checkHighCycleRate();
       }
     } catch (RuntimeException e) {
       // should hopefully never occur


### PR DESCRIPTION
## Description
Added a HighCycleThrottle class which can be used by defining USE_EPOLL_SELECTOR_FIX as an environment variable.  When this variable is defined, the HighCycleThrottle class will introduce a 1 ms delay when high cycling is detected and remove the 1 ms delay when running normal.

## Related Issue
This is related to [issue 896](https://github.com/TooTallNate/Java-WebSocket/issues/896).

## Motivation and Context
When running the WebSocketServer on AWS, we see times when the CPU Load goes to 100% and stays there for about 2 hours.  This is caused when the selector.select() quits blocking causing excessive cycles through the code.  After about 2 hours the selector.select() will start blocking again and the CPU load returns to normal.

CPU only goes to 20% instead of 100% with these code changes.
![image](https://user-images.githubusercontent.com/59612894/136197385-d66137c8-fd41-4170-a684-f4e14a00121b.png)

Logging issue:
![image](https://user-images.githubusercontent.com/59612894/136197855-0f6b3346-f6ee-4a09-b802-14c53086187d.png)
Issue cleared:
![image](https://user-images.githubusercontent.com/59612894/136198127-d04a46ea-784a-4a94-9926-fbdb8e676c25.png)


## How Has This Been Tested?
We ran this code on AWS until we saw the condition reported in the logs, observed the throttling, and saw the condition clear.  This code has been running several weeks without any issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
