### PR TITLE
Readme update

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -44,6 +44,10 @@ Then you can just add the latest version to your build.
 ```xml
 compile "org.java-websocket:Java-WebSocket:1.5.2"
 ```
+Or this option if you use gradle 7.0 and above.
+```xml
+implementation 'org.java-websocket:Java-WebSocket:1.5.2'
+```
 
 #### Logging
 


### PR DESCRIPTION
Updated dependencies in the README 

1. Сhanged versions from 1.5.1 to 1.5.2;
2. Added a block for the dependency in gradle 7.0+ (the 'compile' method was removed in this version and must be replaced by 'implementation' or 'api').