### PR TITLE
Option to start the client and server as daemons

### DIFF
--- a/src/main/java/org/java_websocket/AbstractWebSocket.java
+++ b/src/main/java/org/java_websocket/AbstractWebSocket.java
@@ -89,6 +89,12 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
    * @since 1.3.9
    */
   private boolean websocketRunning = false;
+  /**
+   * Attribute to start the connectionLostChecker as daemon
+   *
+   * @since 1.5.3
+   */
+  private boolean daemon = false;
 
   /**
    * Attribute to sync on
@@ -182,7 +188,7 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
   private void restartConnectionLostTimer() {
     cancelConnectionLostTimer();
     connectionLostCheckerService = Executors
-        .newSingleThreadScheduledExecutor(new NamedThreadFactory("connectionLostChecker"));
+        .newSingleThreadScheduledExecutor(new NamedThreadFactory("connectionLostChecker",daemon));
     Runnable connectionLostChecker = new Runnable() {
 
       /**
@@ -307,5 +313,30 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
   public void setReuseAddr(boolean reuseAddr) {
     this.reuseAddr = reuseAddr;
   }
+
+ 
+   /**
+   * Getter to daemon 
+   *
+   * @return whether connectionLostChecker factory spawns threads as daemon
+   * @since 1.5.3
+   */
+  public boolean isDaemon() {
+      return daemon;
+  }
+
+    /**
+   * Setter for daemon
+   * <p>
+   * Enables/disables connectionLostChecker factory spawning daemon threads
+   *
+   * @param daemon whether to enable or disable SO_REUSEADDR
+   * @since 1.5.3
+   */
+  public void setDaemon(boolean daemon) {
+      this.daemon = daemon;
+  }
+  
+  
 
 }

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -148,6 +148,11 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
    * @since 1.4.1
    */
   private DnsResolver dnsResolver = null;
+  
+   /**
+   * Indicates whether the client should be started as daemon.
+   */
+  private boolean daemon;
 
   /**
    * Constructs a WebSocketClient instance and sets it to the connect to the specified URI. The
@@ -372,6 +377,7 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
       throw new IllegalStateException("WebSocketClient objects are not reuseable");
     }
     connectReadThread = new Thread(this);
+    connectReadThread.setDaemon(daemon);
     connectReadThread.setName("WebSocketConnectReadThread-" + connectReadThread.getId());
     connectReadThread.start();
   }
@@ -506,6 +512,7 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
     }
 
     writeThread = new Thread(new WebsocketWriteThread(this));
+    writeThread.setDaemon(daemon);
     writeThread.start();
 
     byte[] rawbuffer = new byte[WebSocketImpl.RCVBUF];
@@ -983,4 +990,18 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
     }
     engine.eot();
   }
+  
+   /**
+   * Indicates whether the client was started as daemon.
+   */
+  public boolean isDaemon() {
+      return daemon;
+  }
+
+   /**
+   * Indicates whether the client should be started as daemon.
+   */
+  public void setDaemon(boolean daemon) {
+      this.daemon = daemon;
+  }  
 }

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -1003,5 +1003,7 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
    */
   public void setDaemon(boolean daemon) {
       this.daemon = daemon;
+      //pass it to the AbstractWebSocket too, to use it on the connectionLostChecker thread factory
+      super.setDaemon(daemon);
   }  
 }

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -339,6 +339,15 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
    */
   public void setDaemon(boolean daemon) {
       this.daemon = daemon;
+      //pass it to the AbstractWebSocket too, to use it on the connectionLostChecker thread factory
+      super.setDaemon(daemon);
+      //we need to apply this to the decoders aswell since they were created during the constructor
+      for (WebSocketWorker w : decoders){
+          if (!w.isAlive()){
+              w.setDaemon(daemon);
+          }
+      }
+      
   }  
   
   /**

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -110,6 +110,10 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
   private List<Draft> drafts;
 
   private Thread selectorthread;
+  /**
+   * Indicates whether the server should be started as daemon.
+   */
+  private boolean daemon;
 
   private final AtomicBoolean isclosed = new AtomicBoolean(false);
 
@@ -245,7 +249,9 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
     if (selectorthread != null) {
       throw new IllegalStateException(getClass().getName() + " can only be started once.");
     }
-    new Thread(this).start();
+   Thread t = new Thread(this);
+   t.setDaemon(daemon);
+   t.start();
   }
 
   /**
@@ -321,6 +327,20 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
     return port;
   }
 
+   /**
+   * Indicates whether the server was started as daemon.
+   */
+  public boolean isDaemon() {
+      return daemon;
+  }
+
+   /**
+   * Indicates whether the server should be started as daemon.
+   */
+  public void setDaemon(boolean daemon) {
+      this.daemon = daemon;
+  }  
+  
   /**
    * Get the list of active drafts
    *

--- a/src/main/java/org/java_websocket/util/NamedThreadFactory.java
+++ b/src/main/java/org/java_websocket/util/NamedThreadFactory.java
@@ -34,14 +34,20 @@ public class NamedThreadFactory implements ThreadFactory {
   private final ThreadFactory defaultThreadFactory = Executors.defaultThreadFactory();
   private final AtomicInteger threadNumber = new AtomicInteger(1);
   private final String threadPrefix;
+  private boolean daemon;
 
   public NamedThreadFactory(String threadPrefix) {
     this.threadPrefix = threadPrefix;
+  }
+   public NamedThreadFactory(String threadPrefix, boolean daemon) {
+    this.threadPrefix = threadPrefix;
+    this.daemon=daemon;
   }
 
   @Override
   public Thread newThread(Runnable runnable) {
     Thread thread = defaultThreadFactory.newThread(runnable);
+    thread.setDaemon(daemon);
     thread.setName(threadPrefix + "-" + threadNumber);
     return thread;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a new setter to the client and server (.setDaemon), to be used before starting the client/server.
When set to true, all threads spawned by the server and client will be marked as daemon to allow for the exit of the application.

## Related Issue
Fixes #888 

## Motivation and Context
I have an app that is using this library and whenever I closed the app I noticed it never exited, it kept running on the background despite closing the window. I found out the issue was caused by this library since threads spawned were not marked as daemon nor there was a way to specify it. I forked the library and fixed it and then I saw there was already an issue about it so I thought about contributing.

## How Has This Been Tested?
I started a client and server and called .setDaemon(true) , then I closed the window of my app and it exited correctly instead of running itself on the background.

## Types of changes
- [ ] Bug fix 
- [X] New feature
- [ ] Breaking change 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
