### PR TITLE
high cpu when channel close exception fix

### DIFF
--- a/src/main/java/org/java_websocket/SSLSocketChannel2.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel2.java
@@ -385,10 +385,13 @@ public class SSLSocketChannel2 implements ByteChannel, WrappedByteChannel, ISSLC
   public void close() throws IOException {
     sslEngine.closeOutbound();
     sslEngine.getSession().invalidate();
-    if (socketChannel.isOpen()) {
-      socketChannel.write(wrap(emptybuffer));// FIXME what if not all bytes can be written
+    try {
+      if (socketChannel.isOpen()) {
+        socketChannel.write(wrap(emptybuffer));
+      }
+    } finally { // in case socketChannel.write produce exception - channel will never close
+      socketChannel.close();
     }
-    socketChannel.close();
   }
 
   private boolean isHandShakeComplete() {


### PR DESCRIPTION
## Description
There can be IOException when trying to close channel. That create infinitive loop.

## Related Issue
#459 #458 

## How Has This Been Tested?
Tested on my production one week. Standart connection count from 500 up to 2k

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
