### PR TITLE
Issue-1160 Added java.lang.Error handling in WebSocketImpl and WebSocketServer

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -417,7 +417,7 @@ public class WebSocketImpl implements WebSocket {
       log.error("Closing web socket due to an error during frame processing");
       Exception exception = new Exception(e);
       wsl.onWebsocketError(this, exception);
-      String errorMessage = "Got error " + e.getClass().getName() + " on the server side";
+      String errorMessage = "Got error " + e.getClass().getName();
       close(CloseFrame.UNEXPECTED_CONDITION, errorMessage);
     }
   }

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -417,7 +417,7 @@ public class WebSocketImpl implements WebSocket {
       throw e;
     } catch (Error e) {
       log.error("Closing web socket due to an error during frame processing");
-      Exception exception = new Exception(e.getMessage());
+      Exception exception = new Exception(e);
       wsl.onWebsocketError(this, exception);
       close(CloseFrame.UNEXPECTED_CONDITION, exception.getMessage());
     }

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -26,8 +26,6 @@
 package org.java_websocket;
 
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
@@ -419,7 +417,8 @@ public class WebSocketImpl implements WebSocket {
       log.error("Closing web socket due to an error during frame processing");
       Exception exception = new Exception(e);
       wsl.onWebsocketError(this, exception);
-      close(CloseFrame.UNEXPECTED_CONDITION, exception.getMessage());
+      String errorMessage = "Got error " + e.getClass().getName() + " on the server side";
+      close(CloseFrame.UNEXPECTED_CONDITION, errorMessage);
     }
   }
 

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -1083,7 +1083,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
         if (ws != null) {
           ws.close();
         }
-        log.error("Got fatal error in worker thread" + getName());
+        log.error("Got fatal error in worker thread {}", getName());
         Exception exception = new Exception(e);
         handleFatal(ws, exception);
       } catch (Throwable e) {


### PR DESCRIPTION
Added java.lang.Error handling in WebSocketImpl and WebSocketServer. Fatal Error ( VirtualMachineError | ThreadDeath | LinkageError ) lead to stopping of WebSocketServer. Now non-fatal Error leads to closing of web socket but not stopping of WebSocketServer.

Fixes #1160
