### PR TITLE
Add `reconnectBlocking` method with timeout

### DIFF
--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -321,7 +321,7 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
    *
    * @return Returns whether it succeeded or not.
    * @throws InterruptedException Thrown when the threads get interrupted
-   * @since 1.3.8
+   * @since 1.5.4
    */
   public boolean reconnectBlocking() throws InterruptedException {
     reset();

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -321,7 +321,7 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
    *
    * @return Returns whether it succeeded or not.
    * @throws InterruptedException Thrown when the threads get interrupted
-   * @since 1.5.4
+   * @since 1.3.8
    */
   public boolean reconnectBlocking() throws InterruptedException {
     reset();
@@ -336,7 +336,7 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
    * @param timeUnit The timeout time unit
    * @return Returns whether it succeeded or not.
    * @throws InterruptedException Thrown when the threads get interrupted
-   * @since 1.3.8
+   * @since 1.5.4
    */
   public boolean reconnectBlocking(long timeout, TimeUnit timeUnit) throws InterruptedException {
 	  reset();

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -329,6 +329,21 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
   }
 
   /**
+   * Same as <code>reconnect</code> but blocks with a timeout until the websocket reconnected or 
+   * failed to do so.<br>
+   *
+   * @param timeout  The connect timeout
+   * @param timeUnit The timeout time unit
+   * @return Returns whether it succeeded or not.
+   * @throws InterruptedException Thrown when the threads get interrupted
+   * @since 1.3.8
+   */
+  public boolean reconnectBlocking(long timeout, TimeUnit timeUnit) throws InterruptedException {
+	  reset();
+	  return connectBlocking(timeout, timeUnit);
+  }
+
+  /**
    * Reset everything relevant to allow a reconnect
    *
    * @since 1.3.8


### PR DESCRIPTION
## Description
Add `reconnectBlocking(long timeout, TimeUnit timeUnit)` method similarly to the existing `connectBlocking(long timeout, TimeUnit timeUnit)` method.

## Related Issue
none

## Motivation and Context
In certain (non-reproduable) situations it seems the current reconnectBlocking method does neither finish nor abort. The idea here is to use the same approach with `connectLatch` as is already existing with the `connectBlocking` method. 

## How Has This Been Tested?
does not apply

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
