### PR TITLE
Update SSLSocketChannel2.java

### DIFF
--- a/src/main/java/org/java_websocket/SSLSocketChannel2.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel2.java
@@ -105,6 +105,12 @@ public class SSLSocketChannel2 implements ByteChannel, WrappedByteChannel, ISSLC
    **/
   protected int bufferallocations = 0;
 
+  /**
+   * 2022-06-17 Handshake start time in WSS for the underlying channel. 
+   *            If wss handshake is not completed in 10s, close this channel to prevent cpu overload or unexpected channel error. see #896.
+   */
+  protected long	  handshakeStartTime = System.currentTimeMillis() ;
+  
   public SSLSocketChannel2(SocketChannel channel, SSLEngine sslEngine, ExecutorService exec,
       SelectionKey key) throws IOException {
     if (channel == null || sslEngine == null || exec == null) {
@@ -393,8 +399,21 @@ public class SSLSocketChannel2 implements ByteChannel, WrappedByteChannel, ISSLC
 
   private boolean isHandShakeComplete() {
     HandshakeStatus status = sslEngine.getHandshakeStatus();
-    return status == SSLEngineResult.HandshakeStatus.FINISHED
-        || status == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
+    
+    // handshake status
+    boolean ret = status == SSLEngineResult.HandshakeStatus.FINISHED
+               || status == SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING;
+    
+    if ( ret == false )
+    {
+      // 2022-06-17 If wss handshake is not completed in 10s, close this channel to prevent cpu overload or unexpected channel error. see #896.
+      if ( handshakeStartTime > 0 && ( System.currentTimeMillis() - handshakeStartTime ) > 10000 )
+      {
+        try{close() ;}catch(Exception ex){} ;
+      }
+    }
+
+    return ret;
   }
 
   public SelectableChannel configureBlocking(boolean b) throws IOException {


### PR DESCRIPTION

## Description
   'handshakeStartTime' global long variable is added and isHandShakeComplete()  function is updated.
    In isHandShakeComplete function, if wss handshake is not completed in 10s, close this channel to prevent cpu overload or unexpected channel error.

## Related Issue
   High cpu load #896

## Motivation and Context
   When WSS port is opened, if new client is connected and no ssl packet is received from client,  high cpu load happens.

## How Has This Been Tested?
   1) open wss port
   2) telnet to wss port and wait
   3) high cpu load happens

   
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
