### PR TITLE
Replace usages of deprecated constructor Integer(String) with Integer.parseInt

### DIFF
--- a/src/main/java/org/java_websocket/drafts/Draft.java
+++ b/src/main/java/org/java_websocket/drafts/Draft.java
@@ -331,7 +331,7 @@ public abstract class Draft {
     if (vers.length() > 0) {
       int v;
       try {
-        v = new Integer(vers.trim());
+        v = Integer.parseInt(vers.trim());
         return v;
       } catch (NumberFormatException e) {
         return -1;

--- a/src/test/java/org/java_websocket/example/AutobahnClientTest.java
+++ b/src/test/java/org/java_websocket/example/AutobahnClientTest.java
@@ -91,8 +91,8 @@ public class AutobahnClientTest extends WebSocketClient {
           String[] spl = line.split(" ");
           if (line.startsWith("r")) {
             if (spl.length == 3) {
-              start = new Integer(spl[1]);
-              end = new Integer(spl[2]);
+              start = Integer.parseInt(spl[1]);
+              end = Integer.parseInt(spl[2]);
             }
             if (start != null && end != null) {
               if (start > end) {

--- a/src/test/java/org/java_websocket/example/AutobahnSSLServerTest.java
+++ b/src/test/java/org/java_websocket/example/AutobahnSSLServerTest.java
@@ -90,7 +90,7 @@ public class AutobahnSSLServerTest extends WebSocketServer {
   public static void main(String[] args) throws UnknownHostException {
     int port;
     try {
-      port = new Integer(args[0]);
+      port = Integer.parseInt(args[0]);
     } catch (Exception e) {
       System.out.println("No port specified. Defaulting to 9003");
       port = 9003;

--- a/src/test/java/org/java_websocket/example/AutobahnServerTest.java
+++ b/src/test/java/org/java_websocket/example/AutobahnServerTest.java
@@ -90,13 +90,13 @@ public class AutobahnServerTest extends WebSocketServer {
   public static void main(String[] args) throws UnknownHostException {
     int port, limit;
     try {
-      port = new Integer(args[0]);
+      port = Integer.parseInt(args[0]);
     } catch (Exception e) {
       System.out.println("No port specified. Defaulting to 9003");
       port = 9003;
     }
     try {
-      limit = new Integer(args[1]);
+      limit = Integer.parseInt(args[1]);
     } catch (Exception e) {
       System.out.println("No limit specified. Defaulting to MaxInteger");
       limit = Integer.MAX_VALUE;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replace usages of deprecated constructor Integer(String) with Integer.parseInt

## Motivation and Context
https://docs.oracle.com/javase/9/docs/api/java/lang/Integer.html#Integer-java.lang.String-

> @<!-- -->Deprecated(since="9")
> public Integer​(String s)
>  &nbsp; &nbsp; &nbsp;throws NumberFormatException
> Deprecated. It is rarely appropriate to use this constructor. Use [parseInt(String)](https://docs.oracle.com/javase/9/docs/api/java/lang/Integer.html#parseInt-java.lang.String-) to convert a string to a int primitive, or use [valueOf(String)](https://docs.oracle.com/javase/9/docs/api/java/lang/Integer.html#valueOf-java.lang.String-) to convert a string to an Integer object.
> 

## How Has This Been Tested?

Tests work same as before

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
