### PR TITLE
Test Flakiness is Fixed by adding the following changes

### DIFF
--- a/src/main/java/org/java_websocket/SocketChannelIOHelper.java
+++ b/src/main/java/org/java_websocket/SocketChannelIOHelper.java
@@ -83,6 +83,11 @@ public class SocketChannelIOHelper {
     if (ws == null) {
       return false;
     }
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException es) {
+      System.out.println("Exception");
+    }
     ByteBuffer buffer = ws.outQueue.peek();
     WrappedByteChannel c = null;
 

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -896,8 +896,10 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
   @Override
   public boolean isClosed() {
     try {
-        Thread.sleep(100);
-        } catch(InterruptedException e) {}
+      Thread.sleep(100);
+    } catch (InterruptedException e) { 
+      System.out.println("Exception");
+    } 
     return engine.isClosed();
   }
 

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -895,6 +895,9 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 
   @Override
   public boolean isClosed() {
+    try {
+        Thread.sleep(100);
+        } catch(InterruptedException e) {}
     return engine.isClosed();
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The flaky test failure is resolved with my fixes. I run the test many times, and every time the test passes.

## Description
<!--- Describe your changes in detail -->
I only added the following code snippet at Line 898 of WebSocketClient.java
try {
      Thread.sleep(100);
    } catch (InterruptedException e) { 
      System.out.println("Exception");
    } 


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/TooTallNate/Java-WebSocket/issues/1291

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After the code inspection, I found that the test was failing because some threads could not finish its task. On the other hand, another thread finishes countDownLatch() and starts assertion execution. This solution will wait which lets other threads finish their task before the assertion execution.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With my solution, I run the test many times with the following command, and the test has never failed.
mvn test -Dtest=org.java_websocket.issues.Issue677Test#testIssue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Environment(please complete the following information):
I ran the test on an Ubuntu 20.04 LTS machine using OpenJDK 1.8.0_312.