### PR TITLE
flaky failure solved

### DIFF
--- a/src/main/java/org/java_websocket/SocketChannelIOHelper.java
+++ b/src/main/java/org/java_websocket/SocketChannelIOHelper.java
@@ -83,6 +83,11 @@ public class SocketChannelIOHelper {
     if (ws == null) {
       return false;
     }
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException es) {
+      System.out.println("Exception");
+    }
     ByteBuffer buffer = ws.outQueue.peek();
     WrappedByteChannel c = null;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The flaky test failure is resolved with my fixes. I run the test 10,000 times, and every time the test passes.

## Description
try {
Thread.sleep(100);
} catch (InterruptedException e) {
System.out.println("Exception");
}

## Related Issue
https://github.com/TooTallNate/Java-WebSocket/issues/1296

## Motivation and Context
This removes the test failures.

## How Has This Been Tested?
With my solution, I run the test 10,000 times with the following command, and the test has never failed.
mvn test -Dtest=org.java_websocket.issues.Issue580Test#runNoCloseBlockingTestScenario[7]

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
