### PR TITLE
websocketimpl: avoid string copy unless logging trace message

### DIFF
--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -224,10 +224,11 @@ public class WebSocketImpl implements WebSocket {
    */
   public void decode(ByteBuffer socketBuffer) {
     assert (socketBuffer.hasRemaining());
-    log.trace("process({}): ({})", socketBuffer.remaining(),
-        (socketBuffer.remaining() > 1000 ? "too big to display"
-            : new String(socketBuffer.array(), socketBuffer.position(), socketBuffer.remaining())));
-
+    if (log.isTraceEnabled()) {
+      log.trace("process({}): ({})", socketBuffer.remaining(),
+              (socketBuffer.remaining() > 1000 ? "too big to display"
+                      : new String(socketBuffer.array(), socketBuffer.position(), socketBuffer.remaining())));
+    }
     if (readyState != ReadyState.NOT_YET_CONNECTED) {
       if (readyState == ReadyState.OPEN) {
         decodeFrames(socketBuffer);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
avoid string copy in web socket frame decoding
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
before decoding frames, the implementation logs the first 1000 char from the socket buffer. a string object is created even if log is disabled.
changes: check the logging level before creating the logging parameters

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
[x] minor improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
