### PR TITLE
Make Base64Test independent of JDK

### DIFF
--- a/src/test/java/org/java_websocket/util/Base64Test.java
+++ b/src/test/java/org/java_websocket/util/Base64Test.java
@@ -41,14 +41,20 @@ public class Base64Test {
     Assert.assertEquals("", Base64.encodeBytes(new byte[0]));
     Assert.assertEquals("QHE=",
         Base64.encodeBytes(new byte[]{49, 121, 64, 113, -63, 43, -24, 62, 4, 48}, 2, 2, 0));
-    Assert.assertEquals("H4sIAAAAAAAAADMEALfv3IMBAAAA",
+    assertGzipEncodedBytes("H4sIAAAAAAAA", "MEALfv3IMBAAAA",
         Base64.encodeBytes(new byte[]{49, 121, 64, 113, -63, 43, -24, 62, 4, 48}, 0, 1, 6));
-    Assert.assertEquals("H4sIAAAAAAAAAHMoBABQHKKWAgAAAA==",
+    assertGzipEncodedBytes("H4sIAAAAAAAA", "MoBABQHKKWAgAAAA==",
         Base64.encodeBytes(new byte[]{49, 121, 64, 113, -63, 43, -24, 62, 4, 48}, 2, 2, 18));
     Assert.assertEquals("F63=",
         Base64.encodeBytes(new byte[]{49, 121, 64, 113, 63, 43, -24, 62, 4, 48}, 2, 2, 32));
-    Assert.assertEquals("6sg7---------6Bc0-0F699L-V----==",
+    assertGzipEncodedBytes("6sg7--------", "Bc0-0F699L-V----==",
         Base64.encodeBytes(new byte[]{49, 121, 64, 113, 63, 43, -24, 62, 4, 48}, 2, 2, 34));
+  }
+
+  // see https://bugs.openjdk.org/browse/JDK-8253142
+  private void assertGzipEncodedBytes(String expectedPrefix, String expectedSuffix, String actual) {
+    Assert.assertTrue(actual.startsWith(expectedPrefix));
+    Assert.assertTrue(actual.endsWith(expectedSuffix));
   }
 
   @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Base64Test fails on JDK 16+ due to https://bugs.openjdk.org/browse/JDK-8253142

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1306 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To allow building the project with recent JDKs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running the tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
