### PR TITLE
Align slf4j version between maven and gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,8 @@ publishing {
 }
 
 dependencies {
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-    testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.6'
+    testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.6'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'org.json', name: 'json', version: '20180813'
 }


### PR DESCRIPTION

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1370 
## Motivation and Context
There is inconsitent versions of slf4j dependencies between maven and gradle.