### PR TITLE
Replace <tt> with <code> in javadocs

### DIFF
--- a/src/main/java/org/java_websocket/WebSocketAdapter.java
+++ b/src/main/java/org/java_websocket/WebSocketAdapter.java
@@ -99,7 +99,7 @@ public abstract class WebSocketAdapter implements WebSocketListener {
    * Default implementation for onPreparePing, returns a (cached) PingFrame that has no application
    * data.
    *
-   * @param conn The <tt>WebSocket</tt> connection from which the ping frame will be sent.
+   * @param conn The <code>WebSocket</code> connection from which the ping frame will be sent.
    * @return PingFrame to be sent.
    * @see org.java_websocket.WebSocketListener#onPreparePing(WebSocket)
    */

--- a/src/main/java/org/java_websocket/WebSocketListener.java
+++ b/src/main/java/org/java_websocket/WebSocketListener.java
@@ -38,8 +38,8 @@ import org.java_websocket.handshake.ServerHandshake;
 import org.java_websocket.handshake.ServerHandshakeBuilder;
 
 /**
- * Implemented by <tt>WebSocketClient</tt> and <tt>WebSocketServer</tt>. The methods within are
- * called by <tt>WebSocket</tt>. Almost every method takes a first parameter conn which represents
+ * Implemented by <code>WebSocketClient</code> and <code>WebSocketServer</code>. The methods within are
+ * called by <code>WebSocket</code>. Almost every method takes a first parameter conn which represents
  * the source of the respective event.
  */
 public interface WebSocketListener {
@@ -86,7 +86,7 @@ public interface WebSocketListener {
   /**
    * Called when an entire text frame has been received. Do whatever you want here...
    *
-   * @param conn    The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn    The <code>WebSocket</code> instance this event is occurring on.
    * @param message The UTF-8 decoded message that was received.
    */
   void onWebsocketMessage(WebSocket conn, String message);
@@ -94,7 +94,7 @@ public interface WebSocketListener {
   /**
    * Called when an entire binary frame has been received. Do whatever you want here...
    *
-   * @param conn The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn The <code>WebSocket</code> instance this event is occurring on.
    * @param blob The binary message that was received.
    */
   void onWebsocketMessage(WebSocket conn, ByteBuffer blob);
@@ -103,16 +103,16 @@ public interface WebSocketListener {
    * Called after <var>onHandshakeReceived</var> returns <var>true</var>. Indicates that a complete
    * WebSocket connection has been established, and we are ready to send/receive data.
    *
-   * @param conn The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn The <code>WebSocket</code> instance this event is occurring on.
    * @param d    The handshake of the websocket instance
    */
   void onWebsocketOpen(WebSocket conn, Handshakedata d);
 
   /**
-   * Called after <tt>WebSocket#close</tt> is explicity called, or when the other end of the
+   * Called after <code>WebSocket#close</code> is explicity called, or when the other end of the
    * WebSocket connection is closed.
    *
-   * @param ws     The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param ws     The <code>WebSocket</code> instance this event is occurring on.
    * @param code   The codes can be looked up here: {@link CloseFrame}
    * @param reason Additional information string
    * @param remote Returns whether or not the closing of the connection was initiated by the remote
@@ -123,7 +123,7 @@ public interface WebSocketListener {
   /**
    * Called as soon as no further frames are accepted
    *
-   * @param ws     The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param ws     The <code>WebSocket</code> instance this event is occurring on.
    * @param code   The codes can be looked up here: {@link CloseFrame}
    * @param reason Additional information string
    * @param remote Returns whether or not the closing of the connection was initiated by the remote
@@ -134,7 +134,7 @@ public interface WebSocketListener {
   /**
    * send when this peer sends a close handshake
    *
-   * @param ws     The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param ws     The <code>WebSocket</code> instance this event is occurring on.
    * @param code   The codes can be looked up here: {@link CloseFrame}
    * @param reason Additional information string
    */
@@ -144,7 +144,7 @@ public interface WebSocketListener {
    * Called if an exception worth noting occurred. If an error causes the connection to fail onClose
    * will be called additionally afterwards.
    *
-   * @param conn The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn The <code>WebSocket</code> instance this event is occurring on.
    * @param ex   The exception that occurred. <br> Might be null if the exception is not related to
    *             any specific connection. For example if the server port could not be bound.
    */
@@ -153,7 +153,7 @@ public interface WebSocketListener {
   /**
    * Called a ping frame has been received. This method must send a corresponding pong by itself.
    *
-   * @param conn The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn The <code>WebSocket</code> instance this event is occurring on.
    * @param f    The ping frame. Control frames may contain payload.
    */
   void onWebsocketPing(WebSocket conn, Framedata f);
@@ -162,7 +162,7 @@ public interface WebSocketListener {
    * Called just before a ping frame is sent, in order to allow users to customize their ping frame
    * data.
    *
-   * @param conn The <tt>WebSocket</tt> connection from which the ping frame will be sent.
+   * @param conn The <code>WebSocket</code> connection from which the ping frame will be sent.
    * @return PingFrame to be sent.
    */
   PingFrame onPreparePing(WebSocket conn);
@@ -170,7 +170,7 @@ public interface WebSocketListener {
   /**
    * Called when a pong frame is received.
    *
-   * @param conn The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn The <code>WebSocket</code> instance this event is occurring on.
    * @param f    The pong frame. Control frames may contain payload.
    **/
   void onWebsocketPong(WebSocket conn, Framedata f);
@@ -179,19 +179,19 @@ public interface WebSocketListener {
    * This method is used to inform the selector thread that there is data queued to be written to
    * the socket.
    *
-   * @param conn The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn The <code>WebSocket</code> instance this event is occurring on.
    */
   void onWriteDemand(WebSocket conn);
 
   /**
-   * @param conn The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn The <code>WebSocket</code> instance this event is occurring on.
    * @return Returns the address of the endpoint this socket is bound to.
    * @see WebSocket#getLocalSocketAddress()
    */
   InetSocketAddress getLocalSocketAddress(WebSocket conn);
 
   /**
-   * @param conn The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn The <code>WebSocket</code> instance this event is occurring on.
    * @return Returns the address of the endpoint this socket is connected to, or{@code null} if it
    * is unconnected.
    * @see WebSocket#getRemoteSocketAddress()

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -71,7 +71,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * <tt>WebSocketServer</tt> is an abstract class that only takes care of the
+ * <code>WebSocketServer</code> is an abstract class that only takes care of the
  * HTTP handshake portion of WebSockets. It's up to a subclass to add functionality/purpose to the
  * server.
  */
@@ -183,7 +183,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
 
   /**
    * Creates a WebSocketServer that will attempt to bind/listen on the given <var>address</var>, and
-   * comply with <tt>Draft</tt> version <var>draft</var>.
+   * comply with <code>Draft</code> version <var>draft</var>.
    *
    * @param address              The address (host:port) this server should listen on.
    * @param decodercount         The number of {@link WebSocketWorker}s that will be used to process
@@ -872,7 +872,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
    * Called after an opening handshake has been performed and the given websocket is ready to be
    * written on.
    *
-   * @param conn      The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn      The <code>WebSocket</code> instance this event is occurring on.
    * @param handshake The handshake of the websocket instance
    */
   public abstract void onOpen(WebSocket conn, ClientHandshake handshake);
@@ -880,7 +880,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
   /**
    * Called after the websocket connection has been closed.
    *
-   * @param conn   The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn   The <code>WebSocket</code> instance this event is occurring on.
    * @param code   The codes can be looked up here: {@link CloseFrame}
    * @param reason Additional information string
    * @param remote Returns whether or not the closing of the connection was initiated by the remote
@@ -891,7 +891,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
   /**
    * Callback for string messages received from the remote host
    *
-   * @param conn    The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn    The <code>WebSocket</code> instance this event is occurring on.
    * @param message The UTF-8 decoded message that was received.
    * @see #onMessage(WebSocket, ByteBuffer)
    **/
@@ -919,7 +919,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
   /**
    * Callback for binary messages received from the remote host
    *
-   * @param conn    The <tt>WebSocket</tt> instance this event is occurring on.
+   * @param conn    The <code>WebSocket</code> instance this event is occurring on.
    * @param message The binary message that was received.
    * @see #onMessage(WebSocket, ByteBuffer)
    **/

--- a/src/main/java/org/java_websocket/util/Base64.java
+++ b/src/main/java/org/java_websocket/util/Base64.java
@@ -35,7 +35,7 @@ package org.java_websocket.util;
  * <br>
  * <code>byte[] myByteArray = Base64.decode( encoded );</code>
  *
- * <p>The <tt>options</tt> parameter, which appears in a few places, is used to pass
+ * <p>The <code>options</code> parameter, which appears in a few places, is used to pass
  * several pieces of information to the encoder. In the "higher level" methods such as encodeBytes(
  * bytes, options ) the options parameter can be used to indicate such things as first gzipping the
  * bytes before encoding them, not inserting linefeeds, and encoding using the URL-safe and Ordered
@@ -140,9 +140,9 @@ package org.java_websocket.util;
  *   when data that's being decoded is gzip-compressed and will decompress it
  *   automatically. Generally things are cleaner. You'll probably have to
  *   change some method calls that you were making to support the new
- *   options format (<tt>int</tt>s that you "OR" together).</li>
+ *   options format (<code>int</code>s that you "OR" together).</li>
  *  <li>v1.5.1 - Fixed bug when decompressing and decoding to a
- *   byte[] using <tt>decode( String s, boolean gzipCompressed )</tt>.
+ *   byte[] using <code>decode( String s, boolean gzipCompressed )</code>.
  *   Added the ability to "suspend" encoding in the Output Stream so
  *   you can turn on and off the encoding if you need to embed base64
  *   data in an otherwise "normal" stream (like an XML file).</li>
@@ -873,7 +873,7 @@ public class Base64 {
 
   /**
    * A {@link Base64.OutputStream} will write data to another
-   * <tt>java.io.OutputStream</tt>, given in the constructor,
+   * <code>java.io.OutputStream</code>, given in the constructor,
    * and encode/decode to/from Base64 notation on the fly.
    *
    * @see Base64
@@ -895,7 +895,7 @@ public class Base64 {
     /**
      * Constructs a {@link Base64.OutputStream} in ENCODE mode.
      *
-     * @param out the <tt>java.io.OutputStream</tt> to which data will be written.
+     * @param out the <code>java.io.OutputStream</code> to which data will be written.
      * @since 1.3
      */
     public OutputStream(java.io.OutputStream out) {
@@ -914,7 +914,7 @@ public class Base64 {
      * <p>
      * Example: <code>new Base64.OutputStream( out, Base64.ENCODE )</code>
      *
-     * @param out     the <tt>java.io.OutputStream</tt> to which data will be written.
+     * @param out     the <code>java.io.OutputStream</code> to which data will be written.
      * @param options Specified options.
      * @see Base64#ENCODE
      * @see Base64#DO_BREAK_LINES


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
HTML5 has dropped the `<tt>` tag and new versions of the `javadoc` will refuse to generate such docs:
```
Java-WebSocket/src/main/java/org/java_websocket/server/WebSocketServer.java:922: error: tag not supported in HTML5: tt
   * @param conn    The <tt>WebSocket</tt> instance this event is occurring on.
```

## How Has This Been Tested?
Generating javadocs works and output is formatted as expected

