### PR TITLE
Retrieve default SSL socket factory

### DIFF
--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -45,7 +45,6 @@ import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.net.SocketFactory;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
@@ -543,9 +542,7 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
     if (socketFactory instanceof SSLSocketFactory) {
       factory = (SSLSocketFactory) socketFactory;
     } else {
-      SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
-      sslContext.init(null, null, null);
-      factory = sslContext.getSocketFactory();
+      factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
     }
     socket = factory.createSocket(socket, uri.getHost(), getPort(), true);
   }


### PR DESCRIPTION
Without further configuration TLS v1.2 is enforced when connecting to a server. Thus a connection to a server supporting TLS 1.3 only is refused. Recent JREs use TLS v1.2 and TLS v1.3 as the default value, which can be further adjusted via  _jdk.tls.client.protocols_ property.

## Related Issue
Fixes #1382

## Motivation and Context
Allows to configure TLS versions via a global property: jdk.tls.client.protocols

## Checklist:
- 12 of 721 tests failed. No idea what the cause is. The number is however the same for both master and my branch.