### PR TITLE
Have connectBlocking clean up after a timeout

### DIFF
--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -339,7 +339,9 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
           "You cannot initialize a reconnect out of the websocket thread. Use reconnect in another thread to ensure a successful cleanup.");
     }
     try {
-      if (engine.getReadyState() == ReadyState.NOT_YET_CONNECTED) {
+      // This socket null check ensures we can reconnect a socket that failed to connect. It's an uncommon edge case, but we want to make sure we support it
+      if (engine.getReadyState() == ReadyState.NOT_YET_CONNECTED && socket != null) {
+        // Closing the socket when we have not connected prevents the writeThread from hanging on a write indefinitely during connection teardown
         socket.close();
       }
       closeBlocking();


### PR DESCRIPTION
## Related Issue
Fixes #1397

## Motivation and Context
Previously, `connectBlocking(long, TimeUnit)` would return a boolean indicating whether the connection was set up in the given window. If false was returned, we would continue to attempt connecting in the background. This PR updates `connectBlocking(long, TimeUnit)` to perform cleanup on timeout.

## How Has This Been Tested?
- Unit tests have been run
- See "To Reproduce" steps on https://github.com/TooTallNate/Java-WebSocket/issues/1397 - I used the firewall rules listed, and then updated the sample app linked to run the default client in a in a loop (500 iterations) to verify there were no thread or memory leaks

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change) - `connectBlocking(long, TimeUnit)` behavior has changed

## Checklist:
- [x] My code follows the code style of this project.
- [x] All existing tests passed.

Note: I spent a couple hours spiking a unit test around this change but couldn't come up with anything solid. I found it difficult to simulate the "drop packets mid-connection" firewall rule listed in the linked issue. If we think this is necessary to test, advice on testing would be appreciated.
