### PR TITLE
Add ability to disable default receive buffer size in websocket server

### DIFF
--- a/src/main/java/org/java_websocket/AbstractWebSocket.java
+++ b/src/main/java/org/java_websocket/AbstractWebSocket.java
@@ -103,6 +103,11 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
   private final Object syncConnectionLost = new Object();
 
   /**
+   * Attribute to disable default buffer size
+   */
+  private boolean disableReceiveBufferSize = false;
+
+  /**
    * Get the interval checking for lost connections Default is 60 seconds
    *
    * @return the interval in seconds
@@ -336,4 +341,13 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
   public void setDaemon(boolean daemon) {
     this.daemon = daemon;
   }
+
+  public boolean isReceiveBufferSizeDisabled() {
+    return disableReceiveBufferSize;
+  }
+
+  public void setDisableReceiveBufferSize(boolean disableReceiveBufferSize) {
+    this.disableReceiveBufferSize = disableReceiveBufferSize;
+  }
+
 }

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -578,7 +578,9 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
       server = ServerSocketChannel.open();
       server.configureBlocking(false);
       ServerSocket socket = server.socket();
-      socket.setReceiveBufferSize(WebSocketImpl.RCVBUF);
+      if (!isReceiveBufferSizeDisabled()) {
+        socket.setReceiveBufferSize(WebSocketImpl.RCVBUF);
+      }
       socket.setReuseAddress(isReuseAddr());
       socket.bind(address, getMaxPendingConnections());
       selector = Selector.open();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In our project we encountered performance drops in websocket connection over vpn. During debugging we find out that when `socket.setReceiveBufferSize(WebSocketImpl.RCVBUF);` is not set the performance increases (RRT is smaller and more packets per second are ingested)

![image](https://github.com/TooTallNate/Java-WebSocket/assets/13808993/14038bd3-0e18-4386-9ef1-f5f27fafa68c)



## Motivation and Context
Improve performance

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
