### PR TITLE
Allow setting custom TCP receive buffer size

### DIFF
--- a/src/main/java/org/java_websocket/AbstractWebSocket.java
+++ b/src/main/java/org/java_websocket/AbstractWebSocket.java
@@ -103,6 +103,18 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
   private final Object syncConnectionLost = new Object();
 
   /**
+   * TCP receive buffer size that will be used for sockets (zero means use system default)
+   *
+   * @since 1.5.7
+   */
+  private int receiveBufferSize = 0;
+
+  /**
+   * Used for internal buffer allocations when the socket buffer size is not specified.
+   */
+  protected static int DEFAULT_READ_BUFFER_SIZE = 65536;
+
+  /**
    * Get the interval checking for lost connections Default is 60 seconds
    *
    * @return the interval in seconds
@@ -336,4 +348,29 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
   public void setDaemon(boolean daemon) {
     this.daemon = daemon;
   }
+
+  /**
+   * Returns the TCP receive buffer size that will be used for sockets (or zero, if not explicitly set).
+   * @see java.net.Socket#setReceiveBufferSize(int)
+   *
+   * @since 1.5.7
+   */
+  public int getReceiveBufferSize() {
+    return receiveBufferSize;
+  }
+
+  /**
+   * Sets the TCP receive buffer size that will be used for sockets.
+   * If this is not explicitly set (or set to zero), the system default is used.
+   * @see java.net.Socket#setReceiveBufferSize(int)
+   *
+   * @since 1.5.7
+   */
+  public void setReceiveBufferSize(int receiveBufferSize) {
+    if (receiveBufferSize < 0) {
+      throw new IllegalArgumentException("buffer size < 0");
+    }
+    this.receiveBufferSize = receiveBufferSize;
+  }
+
 }

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -86,11 +86,6 @@ public class WebSocketImpl implements WebSocket {
   public static final int DEFAULT_WSS_PORT = 443;
 
   /**
-   * Initial buffer size
-   */
-  public static final int RCVBUF = 16384;
-
-  /**
    * Logger instance
    *
    * @since 1.4.0

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -481,6 +481,10 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 
       socket.setTcpNoDelay(isTcpNoDelay());
       socket.setReuseAddress(isReuseAddr());
+      int receiveBufferSize = getReceiveBufferSize();
+      if (receiveBufferSize > 0) {
+        socket.setReceiveBufferSize(receiveBufferSize);
+      }
 
       if (!socket.isConnected()) {
         InetSocketAddress addr = dnsResolver == null ? InetSocketAddress.createUnresolved(uri.getHost(), getPort()) : new InetSocketAddress(dnsResolver.resolve(uri), this.getPort());
@@ -531,7 +535,8 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
     writeThread.setDaemon(isDaemon());
     writeThread.start();
 
-    byte[] rawbuffer = new byte[WebSocketImpl.RCVBUF];
+    int receiveBufferSize = getReceiveBufferSize();
+    byte[] rawbuffer = new byte[receiveBufferSize > 0 ? receiveBufferSize : DEFAULT_READ_BUFFER_SIZE];
     int readBytes;
 
     try {

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -578,7 +578,10 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
       server = ServerSocketChannel.open();
       server.configureBlocking(false);
       ServerSocket socket = server.socket();
-      socket.setReceiveBufferSize(WebSocketImpl.RCVBUF);
+      int receiveBufferSize = getReceiveBufferSize();
+      if (receiveBufferSize > 0) {
+        socket.setReceiveBufferSize(receiveBufferSize);
+      }
       socket.setReuseAddress(isReuseAddr());
       socket.bind(address, getMaxPendingConnections());
       selector = Selector.open();
@@ -655,7 +658,8 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
   }
 
   public ByteBuffer createBuffer() {
-    return ByteBuffer.allocate(WebSocketImpl.RCVBUF);
+    int receiveBufferSize = getReceiveBufferSize();
+    return ByteBuffer.allocate(receiveBufferSize > 0 ? receiveBufferSize : DEFAULT_READ_BUFFER_SIZE);
   }
 
   protected void queue(WebSocketImpl ws) throws InterruptedException {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add new setter/getter which controls the TCP receive buffer size (previously hardcoded as 16K)

## Motivation and Context
This is intended to solve #1406 in a more general way

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## TODO
Before merging this I would like to manually verify that setting the buffer size affects performance as expected
