### PR TITLE
Protected methods to customize client thread names.

### DIFF
--- a/src/main/java/org/java_websocket/AbstractWebSocket.java
+++ b/src/main/java/org/java_websocket/AbstractWebSocket.java
@@ -201,7 +201,7 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
   private void restartConnectionLostTimer() {
     cancelConnectionLostTimer();
     connectionLostCheckerService = Executors
-        .newSingleThreadScheduledExecutor(new NamedThreadFactory("connectionLostChecker", daemon));
+        .newSingleThreadScheduledExecutor(new NamedThreadFactory(connectionLostThreadPrefix(), daemon));
     Runnable connectionLostChecker = new Runnable() {
 
       /**
@@ -231,6 +231,10 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
     connectionLostCheckerFuture = connectionLostCheckerService
         .scheduleAtFixedRate(connectionLostChecker, connectionLostTimeout, connectionLostTimeout,
             TimeUnit.NANOSECONDS);
+  }
+
+  protected String connectionLostThreadPrefix () {
+    return "connectionLostChecker";
   }
 
   /**

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -380,8 +380,16 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
     }
     connectReadThread = new Thread(this);
     connectReadThread.setDaemon(isDaemon());
-    connectReadThread.setName("WebSocketConnectReadThread-" + connectReadThread.getId());
+    connectReadThread.setName(connectReadThreadName(connectReadThread.getId()));
     connectReadThread.start();
+  }
+
+  protected String connectReadThreadName (long threadId) {
+    return "WebSocketConnectReadThread-" + threadId;
+  }
+
+  protected String writeThreadName (long threadId) {
+	  return "WebSocketWriteThread-" + threadId;
   }
 
   /**
@@ -819,7 +827,7 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 
     @Override
     public void run() {
-      Thread.currentThread().setName("WebSocketWriteThread-" + Thread.currentThread().getId());
+      Thread.currentThread().setName(writeThreadName(Thread.currentThread().getId()));
       try {
         runWriteData();
       } catch (IOException e) {


### PR DESCRIPTION
## Description
New protected methods allow the default thread names to be customized.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1421

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is useful in projects that have many threads and like to stay organized.

It is also useful when using multiple clients. Each client can name its threads differently. Without this, the threads can't be differentiated by name.

An alternative solution could be a prefix that is used for thread names, with suffixes like:
```
threadPrefix + "-read-" + id
threadPrefix + "-write-" + id
threadPrefix + "-checkConnection"
```
LMK if you would prefer that and I'll update the PR.

Server thread names are not considered in this PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It's very simple, running the client tests all changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
