### PR TITLE
Socket activation

### DIFF
--- a/src/main/example/SocketActivation.java
+++ b/src/main/example/SocketActivation.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2010-2020 Nathan Rajlich
+ *
+ *  Permission is hereby granted, free of charge, to any person
+ *  obtaining a copy of this software and associated documentation
+ *  files (the "Software"), to deal in the Software without
+ *  restriction, including without limitation the rights to use,
+ *  copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following
+ *  conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.java_websocket.WebSocket;
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.drafts.Draft_6455;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.server.WebSocketServer;
+
+/**
+ * This is a "smart" chat server which will exit when no more clients are left, in order to demonstrate socket activation
+ */
+public class SocketActivation extends WebSocketServer {
+
+  AtomicInteger clients = new AtomicInteger(0);
+
+  public SocketActivation(ServerSocketChannel chan) {
+    super(chan);
+  }
+
+  @Override
+  public void onOpen(WebSocket conn, ClientHandshake handshake) {
+    conn.send("Welcome to the server!"); //This method sends a message to the new client
+    broadcast("new connection: " + handshake.getResourceDescriptor()); //This method sends a message to all clients connected
+    if(clients.get() == 0) {
+      broadcast("You are the first client to join");
+    }
+    System.out.println(conn.getRemoteSocketAddress().getAddress().getHostAddress() + " entered the room!");
+    clients.incrementAndGet();
+  }
+
+  @Override
+  public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+    broadcast(conn + " has left the room!");
+    System.out.println(conn + " has left the room!");
+    if(clients.decrementAndGet() <= 0) {
+      System.out.println("No more clients left, exiting");
+      System.exit(0);
+    }
+  }
+
+  @Override
+  public void onMessage(WebSocket conn, String message) {
+    broadcast(message);
+    System.out.println(conn + ": " + message);
+  }
+
+  @Override
+  public void onMessage(WebSocket conn, ByteBuffer message) {
+    broadcast(message.array());
+    System.out.println(conn + ": " + message);
+  }
+
+
+  public static void main(String[] args) throws InterruptedException, IOException {
+    if(System.inheritedChannel() == null) {
+      System.err.println("System.inheritedChannel() is null, make sure this program is started with file descriptor zero being a listening socket");
+      System.exit(1);
+    }
+    SocketActivation s = new SocketActivation((ServerSocketChannel)System.inheritedChannel());
+    s.start();
+    System.out.println(">>>> SocketActivation started on port: " + s.getPort() + " <<<<");
+  }
+
+  @Override
+  public void onError(WebSocket conn, Exception ex) {
+    ex.printStackTrace();
+  }
+
+  @Override
+  public void onStart() {
+    System.out.println("Server started!");
+  }
+
+}

--- a/src/main/example/jws-activation.service
+++ b/src/main/example/jws-activation.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Java-WebSocket systemd activation demo service
+After=network.target jws-activation.socket
+Requires=jws-activation.socket
+
+[Service]
+Type=simple
+# Place the command for running SocketActivation.java in file "$HOME"/jws_activation_command:
+ExecStart=/bin/sh %h/jws_activation_run
+TimeoutStopSec=5
+StandardError=journal
+StandardOutput=journal
+# This is very important - systemd will pass the socket as file descriptor zero, which is what Java expects
+StandardInput=socket
+
+[Install]
+WantedBy=default.target

--- a/src/main/example/jws-activation.socket
+++ b/src/main/example/jws-activation.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=Java-WebSocket systemd activation demo socket
+PartOf=jws-activation.service
+
+[Socket]
+ListenStream=127.0.0.1:9999
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Add support for socket  activation

## Description
<!--- Describe your changes in detail -->
Added new constructor to WebSocketServer which takes an already prepared Channel.
If this constructor is used, then WebSocketServer will not try to open it's own channel, or bind it since it is expected to be handled by user.
This allows to use System.inheritedChannel() together with systemd socket activation, which passes the prepared socket as file descriptor #0.
Also added an example "smart" chat server, which will be brought up and down on-demand by systemd.
I have tested it and it is working as expected.
TODO: a unit test should be added which creates server with an existing Channel.
I am also considering adding a script for running an integration test in a container, to make sure socket activation works as expected with this feature.

## Related Issue
Fixes #1440

## Motivation and Context
Allows to use socket activation with websockets

## How Has This Been Tested?
I ran the new example which is in `src/main/example` as a systemd unit. Server comes up and down as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
