### PR TITLE
fix NOD flaky test

### DIFF
--- a/src/test/java/org/java_websocket/issues/Issue256Test.java
+++ b/src/test/java/org/java_websocket/issues/Issue256Test.java
@@ -31,9 +31,6 @@ import static org.junit.Assume.assumeThat;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import org.java_websocket.WebSocket;
 import org.java_websocket.client.WebSocketClient;
@@ -42,124 +39,107 @@ import org.java_websocket.handshake.ServerHandshake;
 import org.java_websocket.server.WebSocketServer;
 import org.java_websocket.util.SocketUtil;
 import org.java_websocket.util.ThreadCheck;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
 public class Issue256Test {
 
-  private static final int NUMBER_OF_TESTS = 10;
-  private static WebSocketServer ws;
+    @Rule
+    public ThreadCheck zombies = new ThreadCheck();
 
-  private static int port;
-  static CountDownLatch countServerDownLatch = new CountDownLatch(1);
-  @Rule
-  public ThreadCheck zombies = new ThreadCheck();
+    private void runTestScenarioReconnect(boolean closeBlocking) throws Exception {
+        final CountDownLatch countServerDownLatch = new CountDownLatch(1);
+        int port = SocketUtil.getAvailablePort();
+        WebSocketServer ws = new WebSocketServer(new InetSocketAddress(port), 16) {
+            @Override
+            public void onOpen(WebSocket conn, ClientHandshake handshake) {
 
-  @Parameterized.Parameter
-  public int count;
+            }
 
-  @BeforeClass
-  public static void startServer() throws Exception {
-    port = SocketUtil.getAvailablePort();
-    ws = new WebSocketServer(new InetSocketAddress(port), 16) {
-      @Override
-      public void onOpen(WebSocket conn, ClientHandshake handshake) {
+            @Override
+            public void onClose(WebSocket conn, int code, String reason, boolean remote) {
 
-      }
+            }
 
-      @Override
-      public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+            @Override
+            public void onMessage(WebSocket conn, String message) {
+                conn.send(message);
+            }
 
-      }
+            @Override
+            public void onError(WebSocket conn, Exception ex) {
 
-      @Override
-      public void onMessage(WebSocket conn, String message) {
-        conn.send(message);
-      }
+                ex.printStackTrace();
+                assumeThat(true, is(false));
+                System.out.println("There should be no exception!");
+            }
 
-      @Override
-      public void onError(WebSocket conn, Exception ex) {
+            @Override
+            public void onStart() {
+              countServerDownLatch.countDown();
+            }
+        };
+        ws.setConnectionLostTimeout(0);
+        ws.start();
+        countServerDownLatch.await();
+    
+        final CountDownLatch countDownLatch0 = new CountDownLatch(1);
+        final CountDownLatch countDownLatch1 = new CountDownLatch(2);
+        WebSocketClient clt = new WebSocketClient(new URI("ws://localhost:" + port)) {
+            @Override
+            public void onOpen(ServerHandshake handshakedata) {
+              countDownLatch1.countDown();
+            }
 
-        ex.printStackTrace();
-        assumeThat(true, is(false));
-        System.out.println("There should be no exception!");
-      }
+            @Override
+            public void onMessage(String message) {
 
-      @Override
-      public void onStart() {
-        countServerDownLatch.countDown();
-      }
-    };
-    ws.setConnectionLostTimeout(0);
-    ws.start();
-    countServerDownLatch.await();
-  }
+            }
 
-  private void runTestScenarioReconnect(boolean closeBlocking) throws Exception {
-    final CountDownLatch countDownLatch0 = new CountDownLatch(1);
-    final CountDownLatch countDownLatch1 = new CountDownLatch(2);
-    WebSocketClient clt = new WebSocketClient(new URI("ws://localhost:" + port)) {
-      @Override
-      public void onOpen(ServerHandshake handshakedata) {
-        countDownLatch1.countDown();
-      }
+            @Override
+            public void onClose(int code, String reason, boolean remote) {
+                countDownLatch0.countDown();
+            }
 
-      @Override
-      public void onMessage(String message) {
+            @Override
+            public void onError(Exception ex) {
+                ex.printStackTrace();
+                assumeThat(true, is(false));
+                System.out.println("There should be no exception!");
+            }
+        };
+        clt.connectBlocking();
+        if (closeBlocking) {
+            clt.closeBlocking();
+        } else {
+            clt.getSocket().close();
+        }
+        countDownLatch0.await();
+        clt.reconnectBlocking();
+        clt.closeBlocking();
 
-      }
-
-      @Override
-      public void onClose(int code, String reason, boolean remote) {
-        countDownLatch0.countDown();
-      }
-
-      @Override
-      public void onError(Exception ex) {
-        ex.printStackTrace();
-        assumeThat(true, is(false));
-        System.out.println("There should be no exception!");
-      }
-    };
-    clt.connectBlocking();
-    if (closeBlocking) {
-      clt.closeBlocking();
-    } else {
-      clt.getSocket().close();
+        // **Teardown Phase**
+        if (ws != null) {
+            ws.stop(1000); // Wait up to 1 second for the server to stop
+            ws = null;
+        }
+        // Allow time for resources to be released
+        Thread.sleep(100);
     }
-    countDownLatch0.await();
-    clt.reconnectBlocking();
-    clt.closeBlocking();
-  }
 
-  @AfterClass
-  public static void successTests() throws InterruptedException, IOException {
-    ws.stop();
-  }
-
-  @Parameterized.Parameters
-  public static Collection<Integer[]> data() {
-    List<Integer[]> ret = new ArrayList<Integer[]>(NUMBER_OF_TESTS);
-    for (int i = 0; i < NUMBER_OF_TESTS; i++) {
-      ret.add(new Integer[]{i});
+    @Test(timeout = 5000 * 10)
+    public void runReconnectSocketClose() throws Exception {
+        for (int i = 0; i < 10; i++) {
+          runTestScenarioReconnect(false);
+        }
     }
-    return ret;
-  }
 
-  @Test(timeout = 5000)
-  public void runReconnectSocketClose() throws Exception {
-    runTestScenarioReconnect(false);
-  }
-
-  @Test(timeout = 5000)
-  public void runReconnectCloseBlocking() throws Exception {
-    runTestScenarioReconnect(true);
-  }
+    @Test(timeout = 5000 * 10)
+    public void runReconnectCloseBlocking() throws Exception {
+        for (int i = 0; i < 10; i++) {
+          runTestScenarioReconnect(true);
+        }
+    }
 
 }
 

--- a/src/test/java/org/java_websocket/issues/Issue256Test.java
+++ b/src/test/java/org/java_websocket/issues/Issue256Test.java
@@ -119,13 +119,11 @@ public class Issue256Test {
     clt.reconnectBlocking();
     clt.closeBlocking();
 
-    // **Teardown Phase**
     if (ws != null) {
       ws.stop(1000); // Wait up to 1 second for the server to stop
       ws = null;
     }
-    // Allow time for resources to be released
-    Thread.sleep(100);
+    Thread.sleep(100); // Allow time for resources to be released
   }
 
   @Test(timeout = 5000 * NUMBER_OF_TESTS)

--- a/src/test/java/org/java_websocket/issues/Issue256Test.java
+++ b/src/test/java/org/java_websocket/issues/Issue256Test.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 
 public class Issue256Test {
 
+  private static final int NUMBER_OF_TESTS = 10;
   @Rule
   public ThreadCheck zombies = new ThreadCheck();
 
@@ -127,18 +128,19 @@ public class Issue256Test {
     Thread.sleep(100);
   }
 
-  @Test(timeout = 5000 * 10)
+  @Test(timeout = 5000 * NUMBER_OF_TESTS)
   public void runReconnectSocketClose() throws Exception {
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < NUMBER_OF_TESTS; i++) {
       runTestScenarioReconnect(false);
     }
   }
 
-  @Test(timeout = 5000 * 10)
+  @Test(timeout = 5000 * NUMBER_OF_TESTS)
   public void runReconnectCloseBlocking() throws Exception {
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < NUMBER_OF_TESTS; i++) {
       runTestScenarioReconnect(true);
     }
   }
+
 }
 

--- a/src/test/java/org/java_websocket/issues/Issue256Test.java
+++ b/src/test/java/org/java_websocket/issues/Issue256Test.java
@@ -118,7 +118,6 @@ public class Issue256Test {
     countDownLatch0.await();
     clt.reconnectBlocking();
     clt.closeBlocking();
-
     if (ws != null) {
       ws.stop(1000); // Wait up to 1 second for the server to stop
       ws = null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
**Problem Statement:**

1. Shared Static Variables: The use of static variables like ws (the WebSocketServer instance), port, and countServerDownLatch meant that these resources were shared across multiple test instances.
This shared state caused interference between tests, especially when they were run multiple times or in parallel, leading to unpredictable failures.

2. Parameterized Tests with Shared State: Parameterizing the tests without proper isolation led to tests depending on or interfering with each other.
The combination of shared static variables and parameterization exacerbated the flakiness.

**Solution Implemented:**

1. Eliminated Static Variables: Removed the static variables ws, port, and countServerDownLatch.
By using local variables within the test method runTestScenarioReconnect, we prevent shared state between test runs.

2. Removed Parameterization: Eliminated the RunWith(Parameterized.class) annotation and related parameterization code. Instead, used a simple loop within each test method to run the test scenario multiple times (10 iterations), providing the same effect without the complexity and flakiness introduced by parameterization.

## Related Issue
Fixes #1443

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The change eliminates flakiness in the Issue256Test class caused by shared static state, improper resource management, and reliance on parameterization. These issues led to Non-Order-Deterministic (NOD) failures where tests interfered with each other due to shared resources like the WebSocketServer instance and static ports. This change ensures the tests are robust.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

 [iDFlakies](https://github.com/UT-SE-Research/iDFlakies) 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
