### PR TITLE
Fix JUnit 5 config for gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,5 +37,9 @@ publishing {
 dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.15'
     testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.15'
-    testImplementation group: 'org.junit', name: 'junit-bom', version: '5.11.4', ext: 'pom'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.11.4'
+}
+
+test {
+    useJUnitPlatform()  // This is required for JUnit 5
 }


### PR DESCRIPTION
## Description
1. Use the API Maven spec instead of the BOM
2. Specify to use the JUnit Platform instead for the `test` task

## Related Issue
#1457
