### PR TITLE
reconnectBlocking overload that supports timeout

### DIFF
--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -328,6 +328,20 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
   }
 
   /**
+   * Same as <code>reconnect</code> but blocks with a timeout until the websocket connected or failed
+   * to do so.<br>
+   *
+   * @param timeout  The connect timeout
+   * @param timeUnit The timeout time unit
+   * @return Returns whether it succeeded or not.
+   * @throws InterruptedException Thrown when the threads get interrupted
+   */
+  public boolean reconnectBlocking(long timeout, TimeUnit timeUnit) throws InterruptedException {
+    reset();
+    return connectBlocking(timeout, timeUnit);
+  }
+
+  /**
    * Reset everything relevant to allow a reconnect
    *
    * @since 1.3.8


### PR DESCRIPTION
## Description

Added an overload to reconnectBlocking method in WebSocketClient class to allow blocking reconnect with timeout.

## Related Issue

https://github.com/TooTallNate/Java-WebSocket/issues/1464

## Motivation and Context
I need to perform a blocking reconnect with a timeout. There is currently no way to do this without reflection

## How Has This Been Tested?
The two commands in the new method were called from outside the class in my use case and it works, there is not much to test here.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
