### PR TITLE
make subclass can override executeConnectionLostDetection logic

### DIFF
--- a/src/main/java/org/java_websocket/AbstractWebSocket.java
+++ b/src/main/java/org/java_websocket/AbstractWebSocket.java
@@ -241,7 +241,7 @@ public abstract class AbstractWebSocket extends WebSocketAdapter {
    * @param minimumPongTime the lowest/oldest allowable last pong time (in nanoTime) before we
    *                        consider the connection to be lost
    */
-  private void executeConnectionLostDetection(WebSocket webSocket, long minimumPongTime) {
+  protected void executeConnectionLostDetection(WebSocket webSocket, long minimumPongTime) {
     if (!(webSocket instanceof WebSocketImpl)) {
       return;
     }


### PR DESCRIPTION
make subclass can override executeConnectionLostDetection logic

## Description
make subclass can override executeConnectionLostDetection logic.  use custom biz logic to to determine whether to close 
closeConnection.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
make subclass can override executeConnectionLostDetection logic.  use custom biz logic to to determine whether to close 
closeConnection.

## How Has This Been Tested?
make subclass can override executeConnectionLostDetection logic.  use custom biz logic to to determine whether to close 
closeConnection.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
