### PR TITLE
SSLSocketChannel2: avoid wasting resources if no valid handshake is made

### DIFF
--- a/src/main/java/org/java_websocket/SSLSocketChannel2.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel2.java
@@ -190,6 +190,14 @@ public class SSLSocketChannel2 implements ByteChannel, WrappedByteChannel, ISSLC
       if (writeEngineResult.getHandshakeStatus() == HandshakeStatus.FINISHED) {
         createBuffers(sslEngine.getSession());
         return;
+      } else {
+        // processHandshake() can spin in a loop if a connection is made with no SSL handshake,
+        // throttle this by delaying 10ms to avoid consuming a CPU core.
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          // Ignore
+        }
       }
     }
     assert (sslEngine.getHandshakeStatus()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR tries to resolve excessive CPU usage and stale socket when a connection is made towards a SSL WebSocket with no proper handshaking.

## Description
<!--- Describe your changes in detail -->
First commit throttles processHandshake() by 10ms to avoid busy looping and consuming an entire CPU core.
Second commit forcefully closes the socket if no handshake is done under 60s.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#896

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I'm extremely surprised this isn't resolved yet.

I was debugging an issue on my app that sometimes hogs an entire CPU core up.
This was hard to hunt down as it's not consistent.

I finally narrowed it down to a rogue client trying to connect over to my SSL WebSocket server.
With no valid SSL handshake, it hogged up an entire CPU core indefinitely.

This would be an extremely frequent phenomenon unless the device is strictly limited to a controlled local network.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -
Reproducible with a netcat from Linux terminal.
Verified no CPU hogs after PR and close() called after 60s.

No application behavior difference.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
