### PR TITLE
Fix null-pointer vulnerability and restore Android compatibility

### DIFF
--- a/src/main/java/org/java_websocket/drafts/Draft_6455.java
+++ b/src/main/java/org/java_websocket/drafts/Draft_6455.java
@@ -244,7 +244,7 @@ public class Draft_6455 extends Draft {
     boolean hasDefault = false;
     byteBufferList = new ArrayList<>();
     for (IExtension inputExtension : inputExtensions) {
-      if (inputExtension.getClass().equals(DefaultExtension.class)) {
+      if (inputExtension instanceof DefaultExtension) {
         hasDefault = true;
       }
     }


### PR DESCRIPTION
The loop checking the list of input extensions passed as a constructor parameter was blindly calling getClass() on any element in the list. This is not null safe and broke compatibility with some Android versions.

Change the code to a null-safe instanceof check, which also restores Android compatibility.

Fixes Issue #1353.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Simple one-liner fix to make the code more robust and restore Android compatibility.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This fixes the crash on some Android versions:

java.lang.IncompatibleClassChangeError: The method 'java.lang.Class java.lang.Object.getClass()' was expected to be of type interface but instead was found to be of type virtual (declaration of 'org.java_websocket.drafts.Draft_6455')

as reported in #1353 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It restores Android compatibility and makes the code more robust.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Android 8.0 and verified to cure the crash shown above.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
