### PR TITLE
Fix Per-Message Compression Extension support

### DIFF
--- a/src/main/java/org/java_websocket/extensions/permessage_deflate/PerMessageDeflateExtension.java
+++ b/src/main/java/org/java_websocket/extensions/permessage_deflate/PerMessageDeflateExtension.java
@@ -324,6 +324,12 @@ public class PerMessageDeflateExtension extends CompressionExtension {
       Map<String, String> headers = extensionData.getExtensionParameters();
       if (headers.containsKey(SERVER_NO_CONTEXT_TAKEOVER)) {
         serverNoContextTakeover = true;
+      } else {
+        // If the server does not return server_no_context_takeover, the client must not reset the
+        // decompressor (inflater) because that would break communication. Note that in contrast,
+        // the client can reset the compressor (deflater) even if the server does not reset the
+        // decompressor (inflater), so this is not required for client_no_context_takeover below.
+        serverNoContextTakeover = false;
       }
       if (headers.containsKey(CLIENT_NO_CONTEXT_TAKEOVER)) {
         clientNoContextTakeover = true;

--- a/src/main/java/org/java_websocket/extensions/permessage_deflate/PerMessageDeflateExtension.java
+++ b/src/main/java/org/java_websocket/extensions/permessage_deflate/PerMessageDeflateExtension.java
@@ -182,7 +182,7 @@ public class PerMessageDeflateExtension extends CompressionExtension {
 
       if (inputFrame.isFin()) {
         decompress(TAIL_BYTES, output);
-        // If context takeover is disabled for the other side, inflater must be reset.
+        // If context takeover is disabled on the other end, inflater can be reset.
         if (resetInflater) {
           inflater.reset();
         }
@@ -252,7 +252,7 @@ public class PerMessageDeflateExtension extends CompressionExtension {
       if (endsWithTail(outputBytes)) {
         outputLength -= TAIL_BYTES.length;
       }
-      // If context takeover is disabled for this side, deflater must be reset.
+      // If context takeover is disabled on this end, deflater can be reset.
       if (resetDeflater) {
         deflater.reset();
       }

--- a/src/test/java/org/java_websocket/extensions/PerMessageDeflateExtensionTest.java
+++ b/src/test/java/org/java_websocket/extensions/PerMessageDeflateExtensionTest.java
@@ -214,7 +214,7 @@ public class PerMessageDeflateExtensionTest {
   @Test
   public void testGetProvidedExtensionAsClient() {
     PerMessageDeflateExtension deflateExtension = new PerMessageDeflateExtension();
-    assertEquals("permessage-deflate; server_no_context_takeover; client_no_context_takeover",
+    assertEquals("permessage-deflate; server_no_context_takeover",
         deflateExtension.getProvidedExtensionAsClient());
   }
 
@@ -242,6 +242,8 @@ public class PerMessageDeflateExtensionTest {
     PerMessageDeflateExtension deflateExtension = new PerMessageDeflateExtension();
     deflateExtension.setServerNoContextTakeover(false);
     assertFalse(deflateExtension.isServerNoContextTakeover());
+    assertEquals("permessage-deflate",
+        deflateExtension.getProvidedExtensionAsServer());
   }
 
   @Test
@@ -255,6 +257,8 @@ public class PerMessageDeflateExtensionTest {
     PerMessageDeflateExtension deflateExtension = new PerMessageDeflateExtension();
     deflateExtension.setClientNoContextTakeover(true);
     assertTrue(deflateExtension.isClientNoContextTakeover());
+    assertEquals("permessage-deflate; server_no_context_takeover; client_no_context_takeover",
+        deflateExtension.getProvidedExtensionAsClient());
   }
 
   @Test


### PR DESCRIPTION
## Description
The per-message compression extension was badly broken, leading to exceptions and loss of communication between client and server.

Fix the extension negotiation to correctly send the current state of the client_no_context_takeover and server_no_context_takeover configuration variables, and ORing the received extensions with the received ones, to ensure client and server end up with the same configuration.

Fix the application of these configuration variables, which must be swapped on the client vs. the server: The configuration of the deflater on the client side must affect the inflater on the server side, and vice versa.

Remove the requestedParameters map as there is no need for it.

## Related Issue
This fixes issue #1496

## Motivation and Context
The broken extension negotiation and application of configuration made it impossible to use the compression extension WITH context takeover, which is the most efficient compression, and the only one which makes sense for applications using smaller message sizes, like OCPP.

With this fix, the Java-OCA-OCPP library can use efficient compression for OCPP messages.

## How Has This Been Tested?
Tested within the Java-OCA-OCPP library, and an integration test which creates an OCPP client and server and connects these on the local machine. When enabling WebSocket compression with the existing library, the test always crashed with an Exception at the second message exchange, due to the inflater and deflater resets being incorrectly applied.

With this fix, the tests which crashed before all pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
